### PR TITLE
style(): remove vertical alignment of form wizard and add support for longer question labels

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@awell_health/ui-library",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "private": false,
   "description": "UI components to integrate with Awell Health",
   "repository": {

--- a/src/atoms/checkboxButton/checkboxButton.module.scss
+++ b/src/atoms/checkboxButton/checkboxButton.module.scss
@@ -4,7 +4,6 @@
   position: relative;
   display: flex;
   place-items: start;
-  align-items: center;
 }
 
 .checkbox_wrapper {
@@ -19,6 +18,8 @@
     border-radius: var(--awell-checkbox-border-radius);
     border: 1px solid var(--awell-radio-checkbox-border-color);
     margin: 0;
+    position: relative;
+    top: 3px;
 
     @media (min-width: 600px) {
       height: var(--awell-radio-checkbox-height-above-mobile);

--- a/src/atoms/radioButton/radioButton.module.scss
+++ b/src/atoms/radioButton/radioButton.module.scss
@@ -4,7 +4,6 @@
   position: relative;
   display: flex;
   place-items: start;
-  align-items: center;
 }
 
 .radio_wrapper {
@@ -17,6 +16,8 @@
     color: var(--awell-accent-color);
     border: 1px solid var(--awell-radio-checkbox-border-color);
     margin: 0;
+    position: relative;
+    top: 3px;
 
     @media (min-width: 600px) {
       height: var(--awell-radio-checkbox-height-above-mobile);

--- a/src/constants/formFixture.ts
+++ b/src/constants/formFixture.ts
@@ -30,19 +30,40 @@ export const form: Form = {
       dataPointValueType: 'NUMBER',
       options: [
         {
-          id: 'IsunqUEdINiG',
-          value: 0,
+          id: '1',
           label: 'Option 1',
+          value: 0,
         },
         {
-          id: 'ReyaXYJpKwNy',
-          value: 1,
+          id: '2',
           label: 'Option 2',
+          value: 1,
         },
         {
-          id: 'mNgpZbOF-z78',
-          value: 2,
+          id: '3',
           label: 'Option 3',
+          value: 3,
+        },
+        {
+          id: '4',
+          label: 'Option 4',
+          value: 4,
+        },
+        {
+          id: '5',
+          label: 'Option 5',
+          value: 5,
+        },
+        {
+          id: '6',
+          label:
+            'Lorem ipsum is placeholder text commonly used in the graphic, print, and publishing industries for previewing layouts and visual mockups.',
+          value: 6,
+        },
+        {
+          id: '7',
+          label: 'Option 7',
+          value: 7,
         },
       ],
       questionType: 'MULTIPLE_CHOICE',

--- a/src/molecules/multipleChoiceQuestion/MultipleChoiceQuestion.stories.tsx
+++ b/src/molecules/multipleChoiceQuestion/MultipleChoiceQuestion.stories.tsx
@@ -9,18 +9,39 @@ import { ThemeProvider } from '../../atoms'
 const defaultOptions = [
   {
     id: '1',
-    label: 'Never',
+    label: 'Option 1',
     value: 0,
   },
   {
     id: '2',
-    label: 'Sometimes',
+    label: 'Option 2',
     value: 1,
   },
   {
     id: '3',
-    label: 'Always',
-    value: 2,
+    label: 'Option 3',
+    value: 3,
+  },
+  {
+    id: '4',
+    label: 'Option 4',
+    value: 4,
+  },
+  {
+    id: '5',
+    label: 'Option 5',
+    value: 5,
+  },
+  {
+    id: '6',
+    label:
+      'Lorem ipsum is placeholder text commonly used in the graphic, print, and publishing industries for previewing layouts and visual mockups.',
+    value: 6,
+  },
+  {
+    id: '7',
+    label: 'Option 7',
+    value: 7,
   },
 ]
 

--- a/src/molecules/question/Question.tsx
+++ b/src/molecules/question/Question.tsx
@@ -221,13 +221,13 @@ export const Question = ({
         getValues={getValues}
       />
 
-      <div className={classes.error}>
-        {currentError && (
+      {currentError && (
+        <div className={classes.error}>
           <Text variant="textSmall" color="var(--awell-signalError100)">
             {currentError.error}
           </Text>
-        )}
-      </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/molecules/singleChoiceQuestion/singleChoiceQuestion.stories.tsx
+++ b/src/molecules/singleChoiceQuestion/singleChoiceQuestion.stories.tsx
@@ -9,18 +9,39 @@ import { ThemeProvider } from '../../atoms'
 const defaultOptions = [
   {
     id: '1',
-    label: 'Never',
+    label: 'Option 1',
     value: 0,
   },
   {
     id: '2',
-    label: 'Sometimes',
+    label: 'Option 2',
     value: 1,
   },
   {
     id: '3',
-    label: 'Always',
-    value: 2,
+    label: 'Option 3',
+    value: 3,
+  },
+  {
+    id: '4',
+    label: 'Option 4',
+    value: 4,
+  },
+  {
+    id: '5',
+    label: 'Option 5',
+    value: 5,
+  },
+  {
+    id: '6',
+    label:
+      'Lorem ipsum is placeholder text commonly used in the graphic, print, and publishing industries for previewing layouts and visual mockups.',
+    value: 6,
+  },
+  {
+    id: '7',
+    label: 'Option 7',
+    value: 7,
   },
 ]
 

--- a/src/organisms/wizardForm/wizardForm.module.scss
+++ b/src/organisms/wizardForm/wizardForm.module.scss
@@ -5,9 +5,7 @@
   --awell-activity-form-padding: var(--awell-activity-padding);
 
   display: flex;
-  height: calc(100vh - var(--awell-header-height));
   flex-direction: column;
-  justify-content: space-between;
   max-width: var(--awell-activity-form-max-width);
   padding: var(--awell-activity-form-padding);
   margin: 0 auto;
@@ -25,41 +23,10 @@
   }
 
   & .wizard_form {
-    height: 100%;
     display: flex;
     flex-direction: column;
     justify-content: center;
   }
-
-  @media screen and (min-width:768px){
-    margin: 0 auto;
-    padding-bottom: 64px;
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
-  }
-   @media screen and (min-width:1440px){
-     justify-content: center;
-
-     & .wizard_form {
-       height: 50%;
-       display: flex;
-       flex-direction: column;
-       justify-content: center;
-     }
-   }
-
-   @media screen and (min-width:2560px){
-     justify-content: center;
-     padding: 0;
-
-     & .wizard_form {
-       height: 30%;
-       display: flex;
-       flex-direction: column;
-       justify-content: center;
-     }
-   }
 
   & .button_wrapper {
     display: flex;


### PR DESCRIPTION
* Add support for longer question labels
* Remove styling around form wizard that automatically centers it vertically. A consumer of the component might want to center it vertically or not, that's up to the consuming app to handle. Let's keep the layout options we ship with the component as dry as possible for now
* Fixes layout issues with the wizard form component when there are a lot of options

**Before:**
<img width="503" alt="Screenshot 2022-08-12 at 07 28 37" src="https://user-images.githubusercontent.com/5594064/184291143-735a491a-1c6b-473c-94c8-f234881ea5f9.png">

<img width="896" alt="Screenshot 2022-08-12 at 07 56 36" src="https://user-images.githubusercontent.com/5594064/184293428-8ddcaa0b-c7ab-42c7-9a38-e26722d46431.png">

**After:**
<img width="502" alt="Screenshot 2022-08-12 at 07 29 04" src="https://user-images.githubusercontent.com/5594064/184291184-e9cee2fb-1d10-4b7d-b885-2e366c3d4513.png">