### PR TITLE
AST-4990 feat(question): add select implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@awell_health/ui-library",
-  "version": "0.0.59",
+  "version": "0.0.60",
   "private": false,
   "description": "UI components to integrate with Awell Health",
   "repository": {

--- a/src/atoms/select/Select.tsx
+++ b/src/atoms/select/Select.tsx
@@ -51,7 +51,7 @@ export interface SelectProps
   /**
    * Value of the select (if it is controlled)
    */
-  value?: Array<number>
+  value?: Array<number> | number
 }
 
 export const Select = ({
@@ -66,9 +66,28 @@ export const Select = ({
   ...props
 }: SelectProps): JSX.Element => {
   const [isOpen, setIsOpen] = useState(false)
-  const [selected, setSelected] = useState<SelectOption[]>(
-    options.filter((option) => value?.includes(option.value))
+
+  // the incoming value may be an array of numbers or a number, corresponding to an option value,
+  // depending on whether the select is single or multiple type
+  const getInitialValue = (): Array<SelectOption> => {
+    if (type === 'multiple') {
+      return options.filter(
+        (option) => (value as Array<number>)?.includes(option.value) ?? false
+      )
+    }
+    if (type === 'single') {
+      return [
+        options.find((option) => (value as number) === option.value) ??
+          undefined,
+      ].filter((option) => option !== undefined) as Array<SelectOption>
+    }
+    return []
+  }
+
+  const [selected, setSelected] = useState<Array<SelectOption>>(
+    getInitialValue()
   )
+
   const selectWrapperRef = useRef<HTMLDivElement | null>(null)
 
   const handleClickOutside = useCallback(
@@ -161,6 +180,7 @@ export const Select = ({
                   <input
                     type="checkbox"
                     id={`checkbox-${option.value}`}
+                    className={classes.checkbox_input}
                     checked={selected.some(
                       (item) => item.value === option.value
                     )}

--- a/src/atoms/select/Select.tsx
+++ b/src/atoms/select/Select.tsx
@@ -15,7 +15,7 @@ export interface SelectOption {
 }
 
 export interface SelectProps
-  extends Omit<InputHTMLAttributes<HTMLInputElement>, 'onChange'> {
+  extends Omit<InputHTMLAttributes<HTMLInputElement>, 'onChange' | 'value'> {
   /**
    * you can also set any attribute that is native to html button
    */
@@ -48,6 +48,10 @@ export interface SelectProps
    * Number of options to show in dropdown
    */
   optionsShown?: number
+  /**
+   * Value of the select (if it is controlled)
+   */
+  value?: Array<number>
 }
 
 export const Select = ({
@@ -58,10 +62,13 @@ export const Select = ({
   mandatory,
   options,
   optionsShown = 4,
+  value,
   ...props
 }: SelectProps): JSX.Element => {
   const [isOpen, setIsOpen] = useState(false)
-  const [selected, setSelected] = useState<SelectOption[]>([])
+  const [selected, setSelected] = useState<SelectOption[]>(
+    options.filter((option) => value?.includes(option.value))
+  )
   const selectWrapperRef = useRef<HTMLDivElement | null>(null)
 
   const handleClickOutside = useCallback(

--- a/src/atoms/select/select.module.scss
+++ b/src/atoms/select/select.module.scss
@@ -84,3 +84,18 @@
 .checkbox {
   margin-right: 8px;
 }
+
+.checkbox-input {
+  position: absolute;
+  opacity: 0;
+  cursor: pointer;
+  height: 0;
+  width: 0;
+  &:checked ~ .checkbox {
+    background-color: var(--awell-accent-color);
+    border-color: var(--awell-accent-color);
+  }
+  &:checked ~ .checkbox:after {
+    display: block;
+  }
+}

--- a/src/atoms/select/select.stories.tsx
+++ b/src/atoms/select/select.stories.tsx
@@ -106,7 +106,7 @@ export const SingleSelectPrefilled: Story<SelectProps> = ({
           mandatory={mandatory}
           options={options}
           optionsShown={optionsShown}
-          value={[options[0].value]}
+          value={options[0].value}
         />
       </div>
     </ThemeProvider>

--- a/src/atoms/select/select.stories.tsx
+++ b/src/atoms/select/select.stories.tsx
@@ -85,6 +85,42 @@ SingleSelect.parameters = {
   },
 }
 
+export const SingleSelectPrefilled: Story<SelectProps> = ({
+  label,
+  id,
+  onChange,
+  onClick,
+  mandatory,
+  options,
+  optionsShown,
+}) => {
+  return (
+    <ThemeProvider accentColor="#004ac2">
+      <div style={{ width: '50%' }}>
+        <SelectComponent
+          type="single"
+          label={label}
+          onChange={onChange}
+          onClick={onClick}
+          id={id}
+          mandatory={mandatory}
+          options={options}
+          optionsShown={optionsShown}
+          value={[options[0].value]}
+        />
+      </div>
+    </ThemeProvider>
+  )
+}
+
+SingleSelectPrefilled.parameters = {
+  docs: {
+    source: {
+      type: 'code',
+    },
+  },
+}
+
 export const MultipleSelect: Story<SelectProps> = ({
   label,
   id,
@@ -113,6 +149,43 @@ export const MultipleSelect: Story<SelectProps> = ({
 }
 
 MultipleSelect.parameters = {
+  docs: {
+    source: {
+      type: 'code',
+    },
+  },
+}
+
+export const MultipleSelectPrefilled: Story<SelectProps> = ({
+  label,
+  id,
+  onChange,
+  onClick,
+  mandatory,
+  options,
+  optionsShown,
+  value,
+}) => {
+  return (
+    <ThemeProvider accentColor="#004ac2">
+      <div style={{ width: '50%' }}>
+        <SelectComponent
+          type="multiple"
+          label={label}
+          onChange={onChange}
+          onClick={onClick}
+          id={id}
+          mandatory={mandatory}
+          options={options}
+          optionsShown={optionsShown}
+          value={[options[0].value, options[1].value]}
+        />
+      </div>
+    </ThemeProvider>
+  )
+}
+
+MultipleSelectPrefilled.parameters = {
   docs: {
     source: {
       type: 'code',

--- a/src/hostedPages/activities/wizardForm/WizardForm.tsx
+++ b/src/hostedPages/activities/wizardForm/WizardForm.tsx
@@ -71,7 +71,7 @@ export const WizardForm = ({
                 key={currentQuestion.id}
                 errors={errors}
                 labels={questionLabels}
-                  questionTypeConfig={questionTypeConfig}
+                questionTypeConfig={questionTypeConfig}
               />
             </div>
           )}

--- a/src/molecules/question/Question.tsx
+++ b/src/molecules/question/Question.tsx
@@ -9,6 +9,7 @@ import {
   RangeInput,
   DatePicker,
   Description,
+  Select,
 } from '../../atoms'
 import classes from './question.module.scss'
 import React, { useLayoutEffect, useState } from 'react'
@@ -48,7 +49,7 @@ QuestionDataProps): JSX.Element => {
                 onChange={(data) => onChange(data)}
                 questionId={question.id}
                 value={value}
-                mandatory={question.questionConfig?.mandatory}
+                mandatory={config?.mandatory}
               />
             )
           }}
@@ -65,14 +66,28 @@ QuestionDataProps): JSX.Element => {
               config?.mandatory ? getValues(question.id).length > 0 : true,
           }}
           render={({ field: { onChange, value } }) => {
+            if (config?.use_select === true) {
+              return (
+                <Select
+                  id={question.id}
+                  value={value}
+                  label={question.title}
+                  onChange={(data) => onChange(data)}
+                  type="multiple"
+                  options={question.options ?? []}
+                  mandatory={config?.mandatory}
+                />
+              )
+            }
+
             return (
               <MultipleChoiceQuestion
                 label={question.title}
-                options={question.options || []}
+                options={question.options ?? []}
                 onChange={(data) => onChange(data)}
                 questionId={question.id}
                 values={value}
-                mandatory={question.questionConfig?.mandatory}
+                mandatory={config?.mandatory}
               />
             )
           }}
@@ -85,6 +100,20 @@ QuestionDataProps): JSX.Element => {
           control={control}
           rules={{ required: config?.mandatory }}
           render={({ field: { onChange, value } }) => {
+            if (config?.use_select === true) {
+              return (
+                <Select
+                  id={question.id}
+                  value={value}
+                  label={question.title}
+                  onChange={(data) => onChange(data)}
+                  type="single"
+                  options={question.options ?? []}
+                  mandatory={config?.mandatory}
+                />
+              )
+            }
+
             return (
               <SingleChoiceQuestion
                 label={question.title}
@@ -92,7 +121,7 @@ QuestionDataProps): JSX.Element => {
                 onChange={(data) => onChange(data)}
                 questionId={question.id}
                 value={value}
-                mandatory={question.questionConfig?.mandatory}
+                mandatory={config?.mandatory}
               />
             )
           }}
@@ -111,7 +140,7 @@ QuestionDataProps): JSX.Element => {
               label={question.title}
               id={question.id}
               value={value}
-              mandatory={question.questionConfig?.mandatory}
+              mandatory={config?.mandatory}
             />
           )}
         />
@@ -130,7 +159,7 @@ QuestionDataProps): JSX.Element => {
               label={question.title}
               id={question.id}
               value={value}
-              mandatory={question.questionConfig?.mandatory}
+              mandatory={config?.mandatory}
             />
           )}
         />
@@ -149,7 +178,7 @@ QuestionDataProps): JSX.Element => {
               label={question.title}
               id={question.id}
               value={value}
-              mandatory={question.questionConfig?.mandatory}
+              mandatory={config?.mandatory}
             />
           )}
         />
@@ -175,7 +204,7 @@ QuestionDataProps): JSX.Element => {
     //           label={question.title}
     //           id={question.id}
     //           value={value}
-    //           mandatory={question.questionConfig?.mandatory}
+    //           mandatory={config?.mandatory}
     //           availableCountries={availableCountries}
     //           initialCountry={initialCountry}
     //           placeholder={placeholder}
@@ -188,7 +217,7 @@ QuestionDataProps): JSX.Element => {
         <Controller
           name={question.id}
           control={control}
-          defaultValue={question.questionConfig?.slider?.min}
+          defaultValue={config?.slider?.min}
           rules={{ required: config?.mandatory }}
           render={({ field: { onChange, value } }) => {
             return (
@@ -198,7 +227,7 @@ QuestionDataProps): JSX.Element => {
                 id={question.id}
                 sliderConfig={(config as SliderQuestionConfig)?.slider}
                 value={value}
-                mandatory={question.questionConfig?.mandatory}
+                mandatory={config?.mandatory}
               />
             )
           }}
@@ -219,7 +248,7 @@ QuestionDataProps): JSX.Element => {
                 onChange={(data) => onChange(data)}
                 id={question.id}
                 value={dateValue}
-                mandatory={question.questionConfig?.mandatory}
+                mandatory={config?.mandatory}
               />
             )
           }}

--- a/src/molecules/question/Question.tsx
+++ b/src/molecules/question/Question.tsx
@@ -70,7 +70,7 @@ QuestionDataProps): JSX.Element => {
               return (
                 <Select
                   id={question.id}
-                  value={[value.toString()]}
+                  value={value}
                   label={question.title}
                   onChange={(data) => onChange(data)}
                   type="multiple"

--- a/src/molecules/question/Question.tsx
+++ b/src/molecules/question/Question.tsx
@@ -70,7 +70,7 @@ QuestionDataProps): JSX.Element => {
               return (
                 <Select
                   id={question.id}
-                  value={value}
+                  value={[value.toString()]}
                   label={question.title}
                   onChange={(data) => onChange(data)}
                   type="multiple"


### PR DESCRIPTION
Changes:
- bump lib to v0.60
- add Select to WizardForm (via Question component)
- update Select to explicitly accept `value` prop (to support form autosave)
- handle select as a controlled input (i.e. value of select can be prefilled)
- codegen on latest release

NB: Select component does not support autocomplete (not based on MUI autocomplete component)