### PR TITLE
AST-5010: Handle last question being hidden when 2nd last question answer is updated

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@awell_health/ui-library",
-  "version": "0.0.63",
+  "version": "0.0.64",
   "private": false,
   "description": "UI components to integrate with Awell Health",
   "repository": {

--- a/src/atoms/select/select.stories.tsx
+++ b/src/atoms/select/select.stories.tsx
@@ -141,6 +141,7 @@ export const MultipleSelect: Story<SelectProps> = ({
           id={id}
           mandatory={mandatory}
           options={options}
+          value={[]}
           optionsShown={optionsShown}
         />
       </div>

--- a/src/hooks/useWizardForm/useWizardForm.tsx
+++ b/src/hooks/useWizardForm/useWizardForm.tsx
@@ -136,7 +136,18 @@ const useWizardForm = ({
   }
 
   const handleGoToNextQuestion = async () => {
-    await updateQuestionVisibility().finally(() => {
+    await updateQuestionVisibility().then((updatedQuestions) => {
+      // check if there are no new visible questions after evaluating rules
+      const doNextQuestionExist = current !== updatedQuestions.length - 1
+      if (!doNextQuestionExist) {
+        // check if there are any errors
+        const hasErrors = handleCheckForErrors()
+        // if there are no errors, submit the form
+        if (!hasErrors) {
+          formMethods.handleSubmit(handleConvertAndSubmitForm)()
+        }
+        return
+      }
       const hasErrors = handleCheckForErrors()
 
       if (!hasErrors) {

--- a/src/hooks/useWizardForm/useWizardForm.tsx
+++ b/src/hooks/useWizardForm/useWizardForm.tsx
@@ -136,24 +136,19 @@ const useWizardForm = ({
   }
 
   const handleGoToNextQuestion = async () => {
-    await updateQuestionVisibility().then((updatedQuestions) => {
-      // check if there are no new visible questions after evaluating rules
-      const doNextQuestionExist = current !== updatedQuestions.length - 1
-      if (!doNextQuestionExist) {
-        // check if there are any errors
-        const hasErrors = handleCheckForErrors()
-        // if there are no errors, submit the form
-        if (!hasErrors) {
+    const hasErrors = handleCheckForErrors()
+    if (!hasErrors) {
+      try {
+        const updatedQuestions = await updateQuestionVisibility()
+        const isLastVisibleQuestion = current === updatedQuestions.length - 1
+        if (isLastVisibleQuestion) {
           formMethods.handleSubmit(handleConvertAndSubmitForm)()
+          return
         }
-        return
-      }
-      const hasErrors = handleCheckForErrors()
-
-      if (!hasErrors) {
+      } finally {
         setCurrent(current + 1)
       }
-    })
+    }
     if (current === -1) {
       setCurrent(current + 1)
     }


### PR DESCRIPTION
https://awellhealth.atlassian.net/browse/AST-5010

Changes:
- in the same way that we assess whether to show a next question before submitting, we also assess whether to submit when handling showing the next question
- bump to 0.0.63

NB: because these updates are await-ed, there's no risk that we submit the form too early. there's also the likely failsafe of form errors (e.g required questions not being answered) that will block form submission if this somehow happened.