### PR TITLE
AST-5003 fix(date-picker): replace date picker with input field

### DIFF
--- a/src/atoms/datePicker/DatePicker.tsx
+++ b/src/atoms/datePicker/DatePicker.tsx
@@ -21,6 +21,9 @@ export interface DatePickerProps {
   mandatory?: boolean
 }
 
+/**
+ * @deprecated use InputField with type 'date' instead
+ */
 export const DatePicker = ({
   id,
   label,
@@ -36,6 +39,10 @@ export const DatePicker = ({
     const formattedDate = date ? format(date, 'yyyy-MM-dd') : null
     onChange(formattedDate)
   }
+
+  console.warn(
+    'DatePicker is deprecated and will be removed in a future release. Please use InputField instead'
+  )
 
   return (
     <div className={'awell_date_picker'} ref={wrapperRef}>

--- a/src/atoms/datePicker/datePicker.stories.tsx
+++ b/src/atoms/datePicker/datePicker.stories.tsx
@@ -1,12 +1,11 @@
 import React from 'react'
 import { Meta, Story } from '@storybook/react/types-6-0'
-import { DatePicker as DatePickerComponent } from '.'
-import { DatePickerProps } from './DatePicker'
 import { ThemeProvider } from '../themeProvider'
+import { InputField, InputFieldProps } from '../inputField'
 
 export default {
-  title: 'atoms/Date Picker',
-  component: DatePickerComponent,
+  title: 'atoms/Input Field',
+  component: InputField,
   argTypes: {
     label: {
       control: 'text',
@@ -17,8 +16,8 @@ export default {
       defaultValue: 'date-picker-story-id',
     },
     value: {
-      control: 'date',
-      defaultValue: new Date(),
+      control: 'string',
+      defaultValue: '2023-03-20',
     },
     mandatory: {
       control: 'boolean',
@@ -41,20 +40,52 @@ export default {
   ],
 } as Meta
 
-export const DatePicker: Story<DatePickerProps> = ({
+export const DateInput: Story<InputFieldProps> = ({
   id,
   label,
   onChange,
   value,
   mandatory,
 }) => {
+  const [date, setDate] = React.useState(value)
+
   return (
-    <DatePickerComponent
-      label={label}
-      mandatory={mandatory}
-      id={id}
-      onChange={onChange}
-      value={value}
-    />
+    <>
+      <InputField
+        type="date"
+        label={label}
+        onChange={(e) => {
+          setDate(e.target.value)
+          onChange(e)
+        }}
+        id={id}
+        value={date}
+        mandatory={mandatory}
+      />
+      <br />
+      <p style={{ width: '40%' }}>
+        If working with incoming values that are Date objects in your app, you
+        can use a <code>formatDate</code> function like below to convert it to a
+        string that can be used in the <code>value</code> prop. The Awell API
+        expects dates to be formatted as <code>yyyy-MM-dd</code>, same as it is
+        for native <code>input</code> elements.
+      </p>
+      <code>
+        <pre>
+          {`
+import { format } from 'date-fns'
+
+const formatDate = (date: Date | null) => {
+  if (!date) return format(new Date(), 'yyyy-MM-dd')
+  return format(date, 'yyyy-MM-dd')
+}
+
+console.log(
+  formatDate(new Date(value)) // => '2023-03-20'
+)
+          `}
+        </pre>
+      </code>
+    </>
   )
 }

--- a/src/atoms/themeProvider/ThemeProvider.tsx
+++ b/src/atoms/themeProvider/ThemeProvider.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from 'react'
-import { getTextColor, opacityColor, shadeColor } from './helpers'
+import { getTextColor, opacityColor } from './helpers'
 import classes from './themeProvider.module.scss'
 
 export interface ThemeProviderProps {

--- a/src/hostedPages/activities/wizardForm/__testdata__/testFormFixture.ts
+++ b/src/hostedPages/activities/wizardForm/__testdata__/testFormFixture.ts
@@ -218,6 +218,21 @@ export const form: Form = {
       },
     },
     {
+      id: 'VkL1vrscT5sdMV',
+      title: 'This is date question',
+      definition_id: 'Kzar2NafTxJfR',
+      key: 'thisIsDateQuestion',
+      dataPointValueType: DataPointValueType.Date,
+      options: [],
+      questionType: QuestionType.Input,
+      userQuestionType: UserQuestionType.Date,
+      questionConfig: {
+        recode_enabled: false,
+        mandatory: false,
+        slider: null,
+      },
+    },
+    {
       id: 'VkL1vrscT5MV',
       title: 'This is yes or no question',
       definition_id: 'Kzr2NafTxJfR',

--- a/src/hostedPages/activities/wizardForm/wizardForm.stories.tsx
+++ b/src/hostedPages/activities/wizardForm/wizardForm.stories.tsx
@@ -79,7 +79,8 @@ export const WizardForm: Story = ({
             search_placeholder: 'Search',
           },
         }}
-        evaluateDisplayConditions={async () => {
+        evaluateDisplayConditions={async (response) => {
+          action('evaluateDisplayConditions')(response)
           return Promise.all([]).then(function () {
             return []
           })

--- a/src/molecules/question/Question.tsx
+++ b/src/molecules/question/Question.tsx
@@ -263,7 +263,7 @@ export const QuestionData = ({
               <InputField
                 type="date"
                 label={question.title}
-                onChange={(data) => onChange(data)}
+                onChange={(event) => onChange(event.target.value)}
                 id={question.id}
                 value={value}
                 mandatory={config?.mandatory}

--- a/src/molecules/question/Question.tsx
+++ b/src/molecules/question/Question.tsx
@@ -259,14 +259,13 @@ export const QuestionData = ({
           control={control}
           rules={{ required: config?.mandatory }}
           render={({ field: { onChange, value } }) => {
-            const dateValue = value ? new Date(value) : null
-
             return (
-              <DatePicker
+              <InputField
+                type="date"
                 label={question.title}
                 onChange={(data) => onChange(data)}
                 id={question.id}
-                value={dateValue}
+                value={value}
                 mandatory={config?.mandatory}
               />
             )


### PR DESCRIPTION
Changes:
- replace DatePicker component for date questions with native input field (date type) -- this uses the browser's native date picker UI to render the input and picker, which is what we use in Studio/Care
- remove `Date Picker` story and add `Input Field` sub-story for date type inputs
- add deprecated warning to DatePicker component

![image](https://user-images.githubusercontent.com/2485818/230370928-61bae294-970b-48a8-8d99-e2c69609c47d.png)

![image](https://user-images.githubusercontent.com/2485818/230403039-712883f2-abd2-41fe-8cc3-1e35caa176a0.png)

![image](https://user-images.githubusercontent.com/2485818/230403086-c1a3e198-6a36-4118-b204-bf5cf2281f35.png)


NB: this is a quick fix for the alignment issue with little downside, we can always revisit the choice of date picker down the line