### PR TITLE
AST-5099: add dir="ltr" to inputs

### DIFF
--- a/src/atoms/inputField/InputField.tsx
+++ b/src/atoms/inputField/InputField.tsx
@@ -51,6 +51,7 @@ export const InputField = ({
         className={classes.awell_input_field}
         onChange={onChange}
         data-testid={`input-${id}`}
+        dir="ltr"
       />
     </div>
   )

--- a/src/atoms/longTextField/LongTextField.tsx
+++ b/src/atoms/longTextField/LongTextField.tsx
@@ -43,6 +43,7 @@ export const LongTextField = ({
         rows={DEFAULT_ROWS}
         className={classes.awell_long_text_field}
         onChange={onChange}
+        dir="ltr"
       />
     </div>
   )

--- a/src/atoms/phoneInputField/PhoneInputField.tsx
+++ b/src/atoms/phoneInputField/PhoneInputField.tsx
@@ -14,7 +14,8 @@ import {
 import { getDefaultCountries } from './helpers'
 import { ParsedCountry } from 'react-international-phone/build/types'
 
-export interface PhoneInputFieldProps extends InputHTMLAttributes<HTMLInputElement> {
+export interface PhoneInputFieldProps
+  extends InputHTMLAttributes<HTMLInputElement> {
   /**
    * sets label of the button
    */
@@ -78,13 +79,12 @@ export const PhoneInputField = ({
       countries,
     })
 
-
   const handleInputChange: React.ChangeEventHandler<HTMLInputElement> = (e) => {
     handlePhoneValueChange(e)
     onChange(e)
   }
 
-  const handleCountrySelect: ((country: ParsedCountry) => void) = ({ iso2 }) => {
+  const handleCountrySelect: (country: ParsedCountry) => void = ({ iso2 }) => {
     setCountry(iso2)
     onChange({ target: { value: phone } } as any)
   }
@@ -107,7 +107,7 @@ export const PhoneInputField = ({
         />
         <input
           {...props}
-          type='tel'
+          type="tel"
           id={id}
           ref={inputRef}
           className={classes.awell_input_field}
@@ -115,6 +115,7 @@ export const PhoneInputField = ({
           onChange={handleInputChange}
           value={phone}
           data-testid={`input-${id}`}
+          dir="ltr"
         />
       </div>
     </div>

--- a/src/atoms/select/Select.tsx
+++ b/src/atoms/select/Select.tsx
@@ -306,6 +306,7 @@ export const Select = ({
           onClick={filtering ? handleResetSearch : () => null}
           readOnly={!filtering}
           onKeyUp={handleKeyUpOnInput}
+          dir="ltr"
         />
         {type === 'multiple' && selected.length > 0 && showCount && (
           <div className={classes.badge}>{selected.length}</div>


### PR DESCRIPTION
Issue:
- a user reported seeing inputs respond in a RTL fashion (https://awellhealth.slack.com/archives/C03TYH8B20P/p1681287134968239)

Solution:
- while we cannot 'force' LTR and the user's device settings are always prioritised, we can suggest LTR to reduce the likelihood that the browser is unclear on which way inputs should be rendered

Changes:
- right now we only support LTR languages so inputs should default to LTR