### PR TITLE
Sdk changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -379,3 +379,5 @@ npm-debug.log
 /storybook-static
 report.json
 .npmrc
+.yalc
+yalc.lock

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@awell_health/ui-library",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "private": false,
   "description": "UI components to integrate with Awell Health",
   "repository": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,3 +1,4 @@
+import path from 'path'
 import { DEFAULT_EXTENSIONS } from '@babel/core'
 import resolve from '@rollup/plugin-node-resolve'
 import commonjs from '@rollup/plugin-commonjs'
@@ -32,6 +33,20 @@ export default {
       extract: true,
       autoModules: true,
       use: ['sass'],
+      modules: {
+        // custom css class name for easy external styling
+        generateScopedName: (className, filepath, css) => {
+          const filename = path.basename(filepath)
+
+          // ! assumption: css, scss files -> alter regex if more stylesheets are required in this repository
+          const nameWithoutExtension = filename.replace(
+            /(\.module)?\.s?css/,
+            ''
+          )
+
+          return `awell__${nameWithoutExtension}_${className}`
+        },
+      },
     }),
     ts2({
       tsconfigOverride: {

--- a/src/atoms/logo/Logo.tsx
+++ b/src/atoms/logo/Logo.tsx
@@ -8,12 +8,16 @@ export interface LogoProps {
    * when image is not loading correctly and for users who use assistive technologies
    */
   companyName?: string
-  logo?: string
+  logo?: JSX.Element | string
 }
 
 export const Logo = ({
   companyName = 'Awell Health',
   logo = awellLogo,
 }: LogoProps): JSX.Element => {
-  return <img className={classes.awell_logo} alt={companyName} src={logo} />
+  return logo && typeof logo !== 'string' ? (
+    logo
+  ) : (
+    <img className={classes.awell_logo} alt={companyName} src={logo} />
+  )
 }

--- a/src/hostedPages/layouts/HostedPageLayout/HostedPageLayout.tsx
+++ b/src/hostedPages/layouts/HostedPageLayout/HostedPageLayout.tsx
@@ -6,7 +6,7 @@ import classes from './hostedPageLayout.module.scss'
 export interface HostedPageLayoutProps {
   children: React.ReactNode | string
   onCloseHostedPage: () => void
-  logo?: string
+  logo?: JSX.Element | string
 }
 
 export const HostedPageLayout: FC<HostedPageLayoutProps> = ({

--- a/src/molecules/navbar/Navbar.tsx
+++ b/src/molecules/navbar/Navbar.tsx
@@ -4,7 +4,7 @@ import { Logo } from '../../atoms/logo'
 
 export interface NavbarProps {
   companyName?: string
-  logo?: string
+  logo?: JSX.Element | string
   children?: ReactElement
 }
 


### PR DESCRIPTION
This are changes needed by `react-sdk`.

1. Changes to logo - allow react component to be passed instead of just string
2. CSS class name generation -  see `rollup.config.js` and lookup `generateScopedName`. `postcss` by default creates class names with hash so it won't work when styling externally. This change ensures proper class names. 
   - Added `awell__` prefix - please change if not wanted