### PR TITLE
AST-5323 feat(CloseButton): add id to close button to simplify css selection

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@awell_health/ui-library",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "private": false,
   "description": "UI components to integrate with Awell Health",
   "repository": {

--- a/src/hostedPages/layouts/HostedPageLayout/CloseButton/CloseButton.tsx
+++ b/src/hostedPages/layouts/HostedPageLayout/CloseButton/CloseButton.tsx
@@ -1,5 +1,4 @@
-import React from 'react'
-import { FC } from 'react'
+import React, { FC } from 'react'
 import classes from './CloseButton.module.scss'
 
 interface CloseButtonProps {
@@ -8,7 +7,12 @@ interface CloseButtonProps {
 
 export const CloseButton: FC<CloseButtonProps> = ({ onClose }) => {
   return (
-    <button type="button" onClick={onClose} className={classes.close_button}>
+    <button
+      type="button"
+      onClick={onClose}
+      className={classes.close_button}
+      id="awell_close_button"
+    >
       <svg
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 20 20"


### PR DESCRIPTION
Simple modification to CloseButton component to allow it to be selected with a static reference (e.g. getElementById). This enables hiding the component if needed in an embedded AHP instance.

NB: No visual or functional changes

Changes:
- add `id` property to CloseButton component outermost element
- bump package version to v0.1.10

AST-5323