### PR TITLE
AST-5383: change 'next' button label to 'skip' for non-required single-select questions

### DIFF
--- a/src/hostedPages/activities/wizardForm/WizardForm.tsx
+++ b/src/hostedPages/activities/wizardForm/WizardForm.tsx
@@ -3,7 +3,7 @@ import { Button, ProgressIndicator, CircularSpinner } from '../../../atoms'
 import classes from './wizardForm.module.scss'
 import { Question } from '../../../molecules'
 import { useWizardForm } from '../../../hooks/useWizardForm'
-import { WizardFormProps } from '../../../types'
+import { UserQuestionType, WizardFormProps } from '../../../types'
 import { HostedPageFooter } from '../../layouts/HostedPageLayout/HostedPageFooter'
 import { useScrollHint } from '../../../hooks/useScrollHint'
 import layoutClasses from '../../layouts/HostedPageLayout/hostedPageLayout.module.scss'
@@ -59,6 +59,24 @@ export const WizardForm = ({
   useEffect(() => {
     determineShowScrollHint()
   }, [currentQuestion])
+
+  const isQuestionSkippable = () => {
+    if (!currentQuestion.userQuestionType) {
+      return false
+    }
+
+    const shouldQuestionAutoProgress = [
+      UserQuestionType.YesNo,
+      UserQuestionType.MultipleChoice,
+    ].includes(currentQuestion.userQuestionType)
+
+    const isNotRequiredQuestion = !currentQuestion.questionConfig?.mandatory
+    const hasNoAnswerValue = getValues()[currentQuestion.id] === ''
+
+    return (
+      shouldQuestionAutoProgress && isNotRequiredQuestion && hasNoAnswerValue
+    )
+  }
 
   return (
     <>
@@ -118,7 +136,7 @@ export const WizardForm = ({
                 onClick={handleGoToNextQuestion}
                 data-cy="navigateToNextQuestionButton"
               >
-                {buttonLabels.next}
+                {isQuestionSkippable() ? buttonLabels.skip : buttonLabels.next}
               </Button>
             )}
           </div>

--- a/src/hostedPages/activities/wizardForm/wizardForm.spec.tsx
+++ b/src/hostedPages/activities/wizardForm/wizardForm.spec.tsx
@@ -17,6 +17,7 @@ const props = {
     prev: 'Prev',
     next: 'Next',
     submit: 'Submit',
+    skip: 'Skip',
   },
   errorLabels: {
     required: 'Answer for this question is required',

--- a/src/hostedPages/activities/wizardForm/wizardForm.spec.tsx
+++ b/src/hostedPages/activities/wizardForm/wizardForm.spec.tsx
@@ -67,6 +67,13 @@ const clickNextButton = async () => {
   })
 }
 
+const clickSkipButton = async () => {
+  const skipButton = await screen.findByText(buttonLabels.skip)
+  await act(async () => {
+    fireEvent.click(skipButton)
+  })
+}
+
 const clickPrevButton = async () => {
   const prevButton = await screen.findByText(buttonLabels.prev)
   await act(async () => {
@@ -105,7 +112,7 @@ describe('Wizard form', () => {
       expect(evaluateDisplayConditions).toHaveBeenCalledTimes(1)
     )
 
-    await clickNextButton()
+    await clickSkipButton()
 
     await waitFor(() =>
       expect(evaluateDisplayConditions).toHaveBeenCalledTimes(2)
@@ -125,7 +132,7 @@ describe('Wizard form', () => {
     renderWizardFormComponent(formData, evaluateDisplayConditions)
 
     // GO to 1st question
-    await clickNextButton()
+    await clickSkipButton()
 
     // GO to 2nd question
     await clickNextButton()
@@ -135,8 +142,12 @@ describe('Wizard form', () => {
     expect(radioOption).not.toBeChecked()
 
     await act(async () => {
+      // clicking on option will move to next question (3rd question)
       fireEvent.click(radioOption)
     })
+
+    // GO to 2nd question
+    await clickPrevButton()
 
     expect(radioOption).toBeChecked()
 
@@ -151,7 +162,7 @@ describe('Wizard form', () => {
     // Check if evaluate visibility conditions were called each time user
     // navigates to NEXT question + 1 on init
     await waitFor(() =>
-      expect(evaluateDisplayConditions).toHaveBeenCalledTimes(3)
+      expect(evaluateDisplayConditions).toHaveBeenCalledTimes(5)
     )
   })
 
@@ -180,6 +191,9 @@ describe('Wizard form', () => {
       fireEvent.click(radioOption)
     })
     expect(radioOption).toBeChecked()
+
+    // GO back to 1st question
+    await clickPrevButton()
 
     // Try going to 2nd question again
     await clickNextButton()

--- a/src/hostedPages/activities/wizardForm/wizardForm.stories.tsx
+++ b/src/hostedPages/activities/wizardForm/wizardForm.stories.tsx
@@ -25,6 +25,7 @@ export default {
         next: 'Next',
         submit: 'Submit',
         start_form: 'Start form',
+        skip: 'Skip',
       },
     },
     errorLabels: {

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -16,6 +16,7 @@ type ButtonLabels = {
   next: string
   submit: string
   start_form?: string
+  skip?: string
 }
 
 export interface WizardFormProps {


### PR DESCRIPTION
Context here: https://awellhealth.atlassian.net/browse/AST-5383

![2023-07-11 19 57 42](https://github.com/awell-health/ui-library/assets/23508720/fda3777e-e967-48c5-af8a-0699116745bd)

'Skip' button is shown when:
- Question is one of single select type questions (Yes/no or Multi-choice) AND
- Question is not required AND
- Question is not answered already

For other cases, 'Next' button is shown.