### PR TITLE
refactor/bug: fix range input display on Safari, misc improvements

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,9 +1,14 @@
+import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport'
+
 export const parameters = {
-  actions: { argTypesRegex: "^on[A-Z].*" },
+  actions: { argTypesRegex: '^on[A-Z].*' },
   controls: {
     matchers: {
       color: /(background|color)$/i,
       date: /Date$/,
     },
+  },
+  viewport: {
+    viewports: INITIAL_VIEWPORTS,
   },
 }

--- a/.vscode/ui-library.code-workspace
+++ b/.vscode/ui-library.code-workspace
@@ -12,6 +12,9 @@
     "editor.defaultFormatter": "esbenp.prettier-vscode", // Tell VSCode to use Prettier as default file formatter
     "cSpell.words": [
       "awell"
-    ]
+    ],
+    "[typescriptreact]": {
+      "editor.defaultFormatter": "esbenp.prettier-vscode"
+    }
   }
 }

--- a/src/atoms/rangeInput/RangeInput.tsx
+++ b/src/atoms/rangeInput/RangeInput.tsx
@@ -130,7 +130,12 @@ export const RangeInput = ({
 
   return (
     <div>
-      <QuestionLabel htmlFor={id} label={label} mandatory={mandatory} />
+      <QuestionLabel
+        htmlFor={id}
+        label={label}
+        mandatory={mandatory}
+        id={`${id}-label`}
+      />
       <div
         className={`${classes.awell_range_input_wrapper} ${
           sliderConfig.display_marks ? classes.with_marks : ''
@@ -141,7 +146,6 @@ export const RangeInput = ({
           {...props}
           data-testid={id}
           type="range"
-          list={`${id}-min-max-labels`}
           id={id}
           min={sliderConfig.min}
           max={sliderConfig.max}
@@ -149,17 +153,24 @@ export const RangeInput = ({
           className={classes.awell_range_input}
           onChange={handleValueChange}
           onFocus={() => setTouched(true)}
+          aria-valuemin={sliderConfig.min}
+          aria-valuemax={sliderConfig.max}
+          aria-valuenow={(props.value || sliderConfig.min) ?? 0}
+          aria-labelledby={`${id}-label`}
         />
-        <datalist
+        <div
           className={`${classes.awell_range_input_datalist} ${
             sliderConfig.show_min_max_values ? classes.with_min_max_labels : ''
           }`}
           data-testid={`${id}-datalist`}
-          id={`${id}-min-max-labels`}
         >
-          <option value={sliderConfig.min} label={sliderConfig.min_label} />
-          <option value={sliderConfig.max} label={sliderConfig.max_label} />
-        </datalist>
+          <span className={classes.minLabel} aria-label="Minimum value">
+            {sliderConfig.min_label}
+          </span>
+          <span className={classes.maxLabel} aria-label="Maximum value">
+            {sliderConfig.max_label}
+          </span>
+        </div>
         {sliderConfig.is_value_tooltip_on &&
           renderValueTooltip(
             internalValue,

--- a/src/atoms/rangeInput/rangeInput.module.scss
+++ b/src/atoms/rangeInput/rangeInput.module.scss
@@ -71,27 +71,32 @@
     font-size: var(--awell-font-size-sm);
     display: flex;
     justify-content: space-between;
+    position: relative;
 
     &.with_min_max_labels {
       margin-top: 20px;
     }
+    
+    .minLabel {
+      position: absolute;
+      left: 0;
+      bottom: -40px;
+      width: 47.5%;
+      max-width: 250px;
+      text-align: left;
+    }
+    
+    .maxLabel {
+      position: absolute;
+      right: 0;
+      bottom: -40px;
+      width: 47.5%;
+      max-width: 250px;
+      text-align: right;
+    }
 
     @media (min-width: 640px) {
       font-size: var(--awell-font-size-base);
-    }
-
-    & option {
-      width: 47.5%;
-      max-width: 250px;
-      text-wrap: wrap;
-      padding: 0;
-
-      &:first-child {
-        text-align: left;
-      }
-      &:not(:first-child) {
-        text-align: right;
-      }
     }
   }
 

--- a/src/hostedPages/activities/checklist/checklist.module.scss
+++ b/src/hostedPages/activities/checklist/checklist.module.scss
@@ -29,7 +29,7 @@
     > div:not(:first-child) {
       margin-top: var(--awell-spacing-5);
 
-      @media (min-width: 600px) {
+      @media (min-width: 640px) {
         margin-top: var(--awell-spacing-4);
       }
     }

--- a/src/hostedPages/activities/cloudinary/cloudinary.module.scss
+++ b/src/hostedPages/activities/cloudinary/cloudinary.module.scss
@@ -33,7 +33,7 @@
   font-weight: var(--awell-font-extrabold);
   margin-bottom: var(--awell-spacing-8);
 
-  @media (min-width: 600px) {
+  @media (min-width: 640px) {
     margin-bottom: var(--awell-spacing-6);
     font-size: var(--awell-font-size-3xl);
   }
@@ -48,7 +48,7 @@
     height: 3px;
     border-radius: var(--awell-border-radius-lg);
 
-    @media (min-width: 600px) {
+    @media (min-width: 640px) {
       margin-top: var(--awell-spacing-3);
     }
   }

--- a/src/hostedPages/activities/form/__testdata__/eq5d5lFixture.ts
+++ b/src/hostedPages/activities/form/__testdata__/eq5d5lFixture.ts
@@ -1,6 +1,8 @@
 export const form = {
   id: 'c6flqC4da3_C',
   title: 'EQ-5D-5L',
+  trademark:
+    '© EuroQol Research Foundation. EQ-5D™ is a trade mark of the EuroQol Research Foundation.',
   questions: [
     {
       id: 'dV6Qua7n0DLe',
@@ -258,7 +260,7 @@ export const form = {
           min: 0,
           max: 100,
           step_value: 1,
-          display_marks: true,
+          display_marks: false,
           min_label: 'The worst health you can imagine',
           max_label: 'The best health you can imagine',
           is_value_tooltip_on: true,

--- a/src/hostedPages/activities/form/form.stories.tsx
+++ b/src/hostedPages/activities/form/form.stories.tsx
@@ -76,6 +76,7 @@ const MyStory: Story = ({
     <HostedPageLayout
       onCloseHostedPage={() => alert('Stop session')}
       hideCloseButton
+      logo={undefined}
     >
       {isConversationalMode ? (
         <ConversationalFormComponent
@@ -234,6 +235,6 @@ FormMobile.args = {
 FormMobile.parameters = {
   viewport: {
     viewports: INITIAL_VIEWPORTS,
-    defaultViewport: 'galaxys5',
+    defaultViewport: 'iphone6',
   },
 }

--- a/src/molecules/attachmentList/attachmentList.module.scss
+++ b/src/molecules/attachmentList/attachmentList.module.scss
@@ -2,6 +2,6 @@
 
 .awell_attachment_list {
   margin-top: var(--awell-padding-md);
-  max-width: 600px;
+  max-width: 640px;
   width: 100%;
 }


### PR DESCRIPTION
Changes:
- replace RangeInput datalist + option with div + labels, replace relevant CSS
- add ARIA labels to RangeInput component

Other:
- add support for more mobile viewports in Storybook
- standardise width breakpoint to 640px in various components (instead of 600px)
- remove logo from hosted pages layout for form stories

closes V1C-67