### PR TITLE
fix(rangeInput): preserve spacing even when value tooltip is not displayed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@awell-health/ui-library",
-  "version": "0.1.37",
+  "version": "0.1.38",
   "private": false,
   "description": "UI components to integrate with Awell Health",
   "repository": {

--- a/src/atoms/rangeInput/RangeInput.tsx
+++ b/src/atoms/rangeInput/RangeInput.tsx
@@ -160,7 +160,7 @@ export const RangeInput = ({
       <div
         className={`${classes.awell_range_input_wrapper} ${
           display_marks ? classes.with_marks : ''
-        } ${is_value_tooltip_on ? classes.with_tooltip : ''}`}
+        }`}
         style={style}
       >
         <input

--- a/src/atoms/rangeInput/rangeInput.module.scss
+++ b/src/atoms/rangeInput/rangeInput.module.scss
@@ -4,13 +4,10 @@
   position: relative;
   transition: all 0.25s ease-in;
   margin-top: 0;
+  margin-top: var(--awell-spacing-8);
 
   @media (min-width: 640px) {
     --awell-thick-width: 2px;
-  }
-
-  &.with_tooltip {
-    margin-top: var(--awell-spacing-8);
   }
 
   .tooltip_touched {


### PR DESCRIPTION
Changes:
- with introduction of instruction to select value on tooltip, we need to preserve the spacing between the label and input, regardless of whether the value tooltip is set to be shown or not