### PR TITLE
feat(form): use the same loader in forms as we have in hosted pages app

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@awell-health/ui-library",
-  "version": "0.1.43",
+  "version": "0.1.44",
   "private": false,
   "description": "UI components to integrate with Awell Health",
   "repository": {

--- a/src/hostedPages/activities/form/ConversationalForm.tsx
+++ b/src/hostedPages/activities/form/ConversationalForm.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react'
-import { Button, ProgressIndicator, CircularSpinner } from '../../../atoms'
+import { Button, ProgressIndicator, HorizontalSpinner } from '../../../atoms'
 import classes from './form.module.scss'
 import { Question as QuestionComponent } from '../../../molecules'
 import { HostedPageFooter } from '../../layouts/HostedPageLayout/HostedPageFooter'
@@ -84,35 +84,37 @@ export const ConversationalForm = ({
         className={layoutClasses.main_content}
       >
         <div className={`${classes.awell_wizard_form} ${classes.container}`}>
-          <div className={classes.form_progress}>
-            <ProgressIndicator percentageCompleted={percentageCompleted} />
-          </div>
           {isEvaluatingQuestionVisibility ||
           currentQuestion?.id === undefined ? (
             <div className={classes.loadingContainer}>
-              <CircularSpinner size="sm" />
+              <HorizontalSpinner />
             </div>
           ) : (
-            <div className={classes.wizard_form}>
-              <QuestionComponent
-                question={currentQuestion}
-                control={control}
-                getValues={getValues}
-                key={currentQuestion.id}
-                errors={errors}
-                labels={questionLabels}
-                submitAndMoveToNextQuestion={submitAndMoveToNextQuestion}
-                inputAutoFocus={true}
-                shouldAutoProgress={shouldAutoProgress}
-              />
-              {form?.trademark && (
-                <div
-                  className={`${classes.trademark} ${classes.conversational}`}
-                >
-                  {form.trademark}
-                </div>
-              )}
-            </div>
+            <>
+              <div className={classes.form_progress}>
+                <ProgressIndicator percentageCompleted={percentageCompleted} />
+              </div>
+              <div className={classes.wizard_form}>
+                <QuestionComponent
+                  question={currentQuestion}
+                  control={control}
+                  getValues={getValues}
+                  key={currentQuestion.id}
+                  errors={errors}
+                  labels={questionLabels}
+                  submitAndMoveToNextQuestion={submitAndMoveToNextQuestion}
+                  inputAutoFocus={true}
+                  shouldAutoProgress={shouldAutoProgress}
+                />
+                {form?.trademark && (
+                  <div
+                    className={`${classes.trademark} ${classes.conversational}`}
+                  >
+                    {form.trademark}
+                  </div>
+                )}
+              </div>
+            </>
           )}
         </div>
       </main>

--- a/src/hostedPages/activities/form/ConversationalForm.tsx
+++ b/src/hostedPages/activities/form/ConversationalForm.tsx
@@ -77,6 +77,10 @@ export const ConversationalForm = ({
     return false
   }
 
+  // hide progress indicator when all questions are evaluated
+  const hideProgressIndicator =
+    isEvaluatingQuestionVisibility && percentageCompleted === 100
+
   return (
     <>
       <main
@@ -84,6 +88,11 @@ export const ConversationalForm = ({
         className={layoutClasses.main_content}
       >
         <div className={`${classes.awell_wizard_form} ${classes.container}`}>
+          {!hideProgressIndicator && (
+            <div className={classes.form_progress}>
+              <ProgressIndicator percentageCompleted={percentageCompleted} />
+            </div>
+          )}
           {isEvaluatingQuestionVisibility ||
           currentQuestion?.id === undefined ? (
             <div className={classes.loadingContainer}>
@@ -91,9 +100,6 @@ export const ConversationalForm = ({
             </div>
           ) : (
             <>
-              <div className={classes.form_progress}>
-                <ProgressIndicator percentageCompleted={percentageCompleted} />
-              </div>
               <div className={classes.wizard_form}>
                 <QuestionComponent
                   question={currentQuestion}

--- a/src/hostedPages/activities/form/TraditionalForm.tsx
+++ b/src/hostedPages/activities/form/TraditionalForm.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Button, CircularSpinner, Text } from '../../../atoms'
+import { Button, HorizontalSpinner, Text } from '../../../atoms'
 import classes from './form.module.scss'
 import { Question } from '../../../molecules'
 import { useTraditionalForm } from '../../../hooks/useForm'
@@ -44,7 +44,7 @@ export const TraditionalForm = ({
         <div className={`${classes.container}`}>
           {!questionWithVisiblity ? (
             <div className={classes.loadingContainer}>
-              <CircularSpinner size="sm" />
+              <HorizontalSpinner />
             </div>
           ) : (
             <div>

--- a/src/hostedPages/activities/form/form.stories.tsx
+++ b/src/hostedPages/activities/form/form.stories.tsx
@@ -102,6 +102,8 @@ const MyStory: Story = ({
             },
           }}
           evaluateDisplayConditions={async (response) => {
+            await new Promise((resolve) => setTimeout(resolve, 1500))
+
             action('evaluateDisplayConditions')(response)
             return Promise.all([]).then(function () {
               const numberQ = response.find(


### PR DESCRIPTION
This PR changes the loader in Conversational & Traditional Form to be the same as we have in the hosted pages app.

![2024-02-09 15 56 18](https://github.com/awell-health/ui-library/assets/23508720/5ef3a075-66b2-4224-805c-839eff31e496)


