### PR TITLE
TP-1300: add validation for date question in form response

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@awell-health/ui-library",
-  "version": "0.1.51",
+  "version": "0.1.52",
   "private": false,
   "description": "UI components to integrate with Awell Health",
   "repository": {

--- a/src/hooks/useForm/types.ts
+++ b/src/hooks/useForm/types.ts
@@ -29,6 +29,10 @@ export type ErrorLabels = {
   sliderNotTouched: string
   invalidPhoneNumber: string
   formHasErrors: string
+
+  dateCannotBeInTheFuture?: string
+  dateCannotBeInThePast?: string
+  dateCannotBeToday?: string
 }
 
 export type AnswerValue = string | number | number[] | undefined

--- a/src/hooks/useForm/useConversationalForm.tsx
+++ b/src/hooks/useForm/useConversationalForm.tsx
@@ -28,7 +28,7 @@ const useConversationalForm = ({
   onAnswersChange,
 }: FormSettingsContextProps): ConversationalFormContext => {
   const initialValues = convertToFormFormat(storedAnswers, questions)
-  const { isValidE164Number } = useValidate()
+  const { isValidE164Number, validateDateResponse } = useValidate()
   const defaultValues =
     !isEmpty(initialValues) && autosaveAnswers
       ? initialValues
@@ -103,7 +103,8 @@ const useConversationalForm = ({
       currentQuestion,
       formMethods,
       errorLabels,
-      isValidE164Number
+      isValidE164Number,
+      validateDateResponse
     )
     setErrors([...errorsWithoutCurrent, ...existingErrors])
     return existingErrors.length > 0

--- a/src/hooks/useForm/useTraditionalForm.tsx
+++ b/src/hooks/useForm/useTraditionalForm.tsx
@@ -45,7 +45,7 @@ const useTraditionalForm = ({
   const [formHasErrors, setFormHasErrors] = useState<boolean>(false)
   const [isSubmittingForm, setIsSubmittingForm] = useState<boolean>(false)
 
-  const { isValidE164Number } = useValidate()
+  const { isValidE164Number, validateDateResponse } = useValidate()
 
   const updateQuestionVisibility = useCallback(async () => {
     const formValuesInput = convertToAwellInput(formMethods.getValues())
@@ -89,7 +89,13 @@ const useTraditionalForm = ({
   const submitForm = async () => {
     await updateQuestionVisibility()
     const errors = visibleQuestions.flatMap((vq) =>
-      getErrorsForQuestion(vq, formMethods, errorLabels, isValidE164Number)
+      getErrorsForQuestion(
+        vq,
+        formMethods,
+        errorLabels,
+        isValidE164Number,
+        validateDateResponse
+      )
     )
     setErrors(errors)
     if (errors.length == 0) {

--- a/src/hooks/useValidate/useValidate.test.ts
+++ b/src/hooks/useValidate/useValidate.test.ts
@@ -1,5 +1,6 @@
 import { renderHook } from '@testing-library/react-hooks'
 import { useValidate } from './useValidate'
+import { AllowedDatesOptions } from '../../types'
 
 describe('useValidate', () => {
   describe('validatePhoneNumber', () => {
@@ -115,6 +116,179 @@ describe('useValidate', () => {
           'ca',
         ])
       expect(matchesAvailableCountries).toBe(false)
+    })
+  })
+
+  describe('validateDateResponse', () => {
+    // Mock current date to ensure consistent results
+    beforeAll(() => {
+      jest.useFakeTimers().setSystemTime(new Date('2024-01-01'))
+    })
+
+    describe('when date configuration is not defined', () => {
+      it('should return isValid set to true', () => {
+        const { result } = renderHook(() => useValidate())
+        const pastDate = '2023-01-01'
+        expect(
+          result.current.validateDateResponse(undefined, pastDate).isValid
+        ).toBe(true)
+        const todayDate = '2024-01-01'
+        expect(
+          result.current.validateDateResponse(undefined, todayDate).isValid
+        ).toBe(true)
+        const futureDate = '2024-01-05'
+        expect(
+          result.current.validateDateResponse(undefined, futureDate).isValid
+        ).toBe(true)
+      })
+    })
+
+    describe('when date should be in the past', () => {
+      it('should return isValid set to true when value is in the past', () => {
+        const dateConfig = {
+          mandatory: false,
+          date: {
+            allowed_dates: AllowedDatesOptions.Past,
+          },
+        }
+        const { result } = renderHook(() => useValidate())
+        const pastDate = '2023-01-01'
+        expect(
+          result.current.validateDateResponse(dateConfig, pastDate).isValid
+        ).toBe(true)
+      })
+
+      it('should return isValid set to false when value is in the future', () => {
+        const dateConfig = {
+          mandatory: false,
+          date: {
+            allowed_dates: AllowedDatesOptions.Past,
+          },
+        }
+        const { result } = renderHook(() => useValidate())
+        const futureDate = '2024-01-02'
+        expect(
+          result.current.validateDateResponse(dateConfig, futureDate).isValid
+        ).toBe(false)
+        expect(
+          result.current.validateDateResponse(dateConfig, futureDate).errorType
+        ).toBe('DATE_CANNOT_BE_IN_THE_FUTURE')
+      })
+
+      it('should return isValid set to false when value is today date and date of response is not allowed', () => {
+        const dateConfig = {
+          mandatory: false,
+          date: {
+            allowed_dates: AllowedDatesOptions.Past,
+          },
+        }
+        const { result } = renderHook(() => useValidate())
+        const todayDate = '2024-01-01'
+        expect(
+          result.current.validateDateResponse(dateConfig, todayDate).isValid
+        ).toBe(false)
+        expect(
+          result.current.validateDateResponse(dateConfig, todayDate).errorType
+        ).toBe('DATE_CANNOT_BE_TODAY')
+      })
+
+      it('should return isValid set to true when value is today date and date of response is allowed', () => {
+        const dateConfig = {
+          mandatory: false,
+          date: {
+            allowed_dates: AllowedDatesOptions.Past,
+            include_date_of_response: true,
+          },
+        }
+        const { result } = renderHook(() => useValidate())
+        const todayDate = '2024-01-01'
+        expect(
+          result.current.validateDateResponse(dateConfig, todayDate).isValid
+        ).toBe(true)
+      })
+    })
+
+    describe('when date should be in the future', () => {
+      it('should return isValid set to true when value is in the future', () => {
+        const dateConfig = {
+          mandatory: false,
+          date: {
+            allowed_dates: AllowedDatesOptions.Future,
+          },
+        }
+        const { result } = renderHook(() => useValidate())
+        const futureDate = '2025-01-01'
+        expect(
+          result.current.validateDateResponse(dateConfig, futureDate).isValid
+        ).toBe(true)
+      })
+
+      it('should return isValid set to false when value is in the future', () => {
+        const dateConfig = {
+          mandatory: false,
+          date: {
+            allowed_dates: AllowedDatesOptions.Future,
+          },
+        }
+        const { result } = renderHook(() => useValidate())
+        const pastDate = '2023-12-02'
+        expect(
+          result.current.validateDateResponse(dateConfig, pastDate).isValid
+        ).toBe(false)
+        expect(
+          result.current.validateDateResponse(dateConfig, pastDate).errorType
+        ).toBe('DATE_CANNOT_BE_IN_THE_PAST')
+      })
+
+      it('should return isValid set to false when value is today date and date of response is not allowed', () => {
+        const dateConfig = {
+          mandatory: false,
+          date: {
+            allowed_dates: AllowedDatesOptions.Future,
+          },
+        }
+        const { result } = renderHook(() => useValidate())
+        const todayDate = '2024-01-01'
+        expect(
+          result.current.validateDateResponse(dateConfig, todayDate).isValid
+        ).toBe(false)
+        expect(
+          result.current.validateDateResponse(dateConfig, todayDate).errorType
+        ).toBe('DATE_CANNOT_BE_TODAY')
+      })
+
+      it('should return isValid set to true when value is today date and date of response is allowed', () => {
+        const dateConfig = {
+          mandatory: false,
+          date: {
+            allowed_dates: AllowedDatesOptions.Future,
+            include_date_of_response: true,
+          },
+        }
+        const { result } = renderHook(() => useValidate())
+        const pastDate = '2024-01-01'
+        expect(
+          result.current.validateDateResponse(dateConfig, pastDate).isValid
+        ).toBe(true)
+      })
+    })
+
+    describe('when all dates are allowed', () => {
+      it('should return isValid set to true', () => {
+        const { result } = renderHook(() => useValidate())
+        const pastDate = '2023-01-01'
+        expect(
+          result.current.validateDateResponse(undefined, pastDate).isValid
+        ).toBe(true)
+        const todayDate = '2024-01-01'
+        expect(
+          result.current.validateDateResponse(undefined, todayDate).isValid
+        ).toBe(true)
+        const futureDate = '2024-01-05'
+        expect(
+          result.current.validateDateResponse(undefined, futureDate).isValid
+        ).toBe(true)
+      })
     })
   })
 })

--- a/src/hooks/useValidate/useValidate.test.ts
+++ b/src/hooks/useValidate/useValidate.test.ts
@@ -275,18 +275,24 @@ describe('useValidate', () => {
 
     describe('when all dates are allowed', () => {
       it('should return isValid set to true', () => {
+        const dateConfig = {
+          mandatory: false,
+          date: {
+            allowed_dates: AllowedDatesOptions.All,
+          },
+        }
         const { result } = renderHook(() => useValidate())
         const pastDate = '2023-01-01'
         expect(
-          result.current.validateDateResponse(undefined, pastDate).isValid
+          result.current.validateDateResponse(dateConfig, pastDate).isValid
         ).toBe(true)
         const todayDate = '2024-01-01'
         expect(
-          result.current.validateDateResponse(undefined, todayDate).isValid
+          result.current.validateDateResponse(dateConfig, todayDate).isValid
         ).toBe(true)
         const futureDate = '2024-01-05'
         expect(
-          result.current.validateDateResponse(undefined, futureDate).isValid
+          result.current.validateDateResponse(dateConfig, futureDate).isValid
         ).toBe(true)
       })
     })

--- a/src/hooks/useValidate/useValidate.ts
+++ b/src/hooks/useValidate/useValidate.ts
@@ -157,10 +157,17 @@ export const useValidate = (): UseValidateHook => {
         isValid: true,
       }
     }
-    if (include_date_of_response !== true && dateIsToday) {
-      return {
-        isValid: false,
-        errorType: 'DATE_CANNOT_BE_TODAY',
+
+    if (dateIsToday) {
+      if (include_date_of_response === true) {
+        return {
+          isValid: true,
+        }
+      } else {
+        return {
+          isValid: false,
+          errorType: 'DATE_CANNOT_BE_TODAY',
+        }
       }
     }
 

--- a/src/hooks/useValidate/useValidate.ts
+++ b/src/hooks/useValidate/useValidate.ts
@@ -1,6 +1,18 @@
 import { validatePhone } from 'react-international-phone'
 import { getDefaultCountries } from '../../atoms/phoneInputField'
 import { ValidatePhoneReturn, CountryIso2 } from './types'
+import {
+  AllowedDatesOptions,
+  Maybe,
+  QuestionConfig,
+} from '../../types/generated/types-orchestration'
+import { isEmpty, isNil } from 'lodash'
+import { isToday } from 'date-fns'
+
+export type DateValidationErrorType =
+  | 'DATE_CANNOT_BE_IN_THE_FUTURE'
+  | 'DATE_CANNOT_BE_IN_THE_PAST'
+  | 'DATE_CANNOT_BE_TODAY'
 
 export interface UseValidateHook {
   validatePhoneNumber: (
@@ -16,6 +28,13 @@ export interface UseValidateHook {
     number: string,
     availableCountries: Array<CountryIso2>
   ) => boolean
+  validateDateResponse: (
+    questionConfig: Maybe<QuestionConfig> | undefined,
+    value: string
+  ) => {
+    isValid: boolean
+    errorType?: DateValidationErrorType
+  }
 }
 
 export const handleUSException = (
@@ -104,10 +123,77 @@ export const useValidate = (): UseValidateHook => {
     return /^\+?[1-9]\d{1,14}$/.test(number)
   }
 
+  const validateDateResponse = (
+    questionConfig: Maybe<QuestionConfig> | undefined,
+    value: string
+  ): {
+    isValid: boolean
+    errorType?: DateValidationErrorType
+  } => {
+    const inputRequired = questionConfig?.mandatory
+
+    // skip validation if input is not required and empty
+    if (inputRequired === false && isEmpty(value)) {
+      return {
+        isValid: true,
+      }
+    }
+
+    // No validation needed if date config is not configured
+    if (!questionConfig || !questionConfig.date) {
+      return {
+        isValid: true,
+      }
+    }
+
+    const parsedDate = new Date(value)
+    const dateIsToday = isToday(parsedDate)
+
+    const { allowed_dates, include_date_of_response = false } =
+      questionConfig.date
+
+    if (allowed_dates === AllowedDatesOptions.All) {
+      return {
+        isValid: true,
+      }
+    }
+    if (include_date_of_response !== true && dateIsToday) {
+      return {
+        isValid: false,
+        errorType: 'DATE_CANNOT_BE_TODAY',
+      }
+    }
+
+    if (
+      allowed_dates === AllowedDatesOptions.Past &&
+      parsedDate >= new Date()
+    ) {
+      return {
+        isValid: false,
+        errorType: 'DATE_CANNOT_BE_IN_THE_FUTURE',
+      }
+    }
+
+    if (
+      allowed_dates === AllowedDatesOptions.Future &&
+      parsedDate <= new Date()
+    ) {
+      return {
+        isValid: false,
+        errorType: 'DATE_CANNOT_BE_IN_THE_PAST',
+      }
+    }
+
+    return {
+      isValid: true,
+    }
+  }
+
   return {
     isValidE164Number,
     isPossibleE164Number,
     validatePhoneNumber,
     numberMatchesAvailableCountries,
+    validateDateResponse,
   }
 }

--- a/src/molecules/question/Question.tsx
+++ b/src/molecules/question/Question.tsx
@@ -15,8 +15,10 @@ import classes from './question.module.scss'
 import React, { useLayoutEffect, useState } from 'react'
 import { QuestionDataProps, QuestionProps } from './types'
 import { PhoneInputField } from '../../atoms/phoneInputField'
-import { CountryIso2 } from '../../hooks/useValidate'
+import { CountryIso2, useValidate } from '../../hooks/useValidate'
 import { isNil, noop } from 'lodash'
+import { getMinValueForDateInput } from './helpers/getMinValueForDateInput'
+import { getMaxValueForDateInput } from './helpers/getMaxValueForDateInput'
 
 const AUTO_PROGRESS_DELAY = 850 // in milliseconds
 
@@ -31,6 +33,7 @@ export const QuestionData = ({
   shouldAutoProgress = () => false,
 }: QuestionDataProps): JSX.Element => {
   const config = question?.questionConfig
+  const { validateDateResponse } = useValidate()
 
   switch (question.userQuestionType) {
     case UserQuestionType.YesNo:
@@ -327,7 +330,9 @@ export const QuestionData = ({
         <Controller
           name={question.id}
           control={control}
-          rules={{ required: config?.mandatory }}
+          rules={{
+            required: config?.mandatory,
+          }}
           render={({ field: { onChange, value } }) => {
             return (
               <InputField
@@ -342,6 +347,8 @@ export const QuestionData = ({
                 id={question.id}
                 value={value}
                 mandatory={config?.mandatory}
+                min={getMinValueForDateInput(config?.date)}
+                max={getMaxValueForDateInput(config?.date)}
               />
             )
           }}

--- a/src/molecules/question/helpers/getMaxValueForDateInput.ts
+++ b/src/molecules/question/helpers/getMaxValueForDateInput.ts
@@ -1,0 +1,21 @@
+import { format, subDays } from 'date-fns'
+import { isNil } from 'lodash'
+import { AllowedDatesOptions, DateConfig, Maybe } from '../../../types'
+
+export const getMaxValueForDateInput = (
+  dateConfig: Maybe<DateConfig> | undefined
+): string | undefined => {
+  if (isNil(dateConfig)) {
+    return undefined
+  }
+
+  if (dateConfig.allowed_dates === AllowedDatesOptions.Past) {
+    if (dateConfig.include_date_of_response === true) {
+      return format(new Date(), 'yyyy-MM-dd')
+    }
+    const dateMinusOneDay = subDays(new Date(), 1)
+
+    return format(dateMinusOneDay, 'yyyy-MM-dd')
+  }
+  return undefined
+}

--- a/src/molecules/question/helpers/getMinValueForDateInput.ts
+++ b/src/molecules/question/helpers/getMinValueForDateInput.ts
@@ -1,0 +1,21 @@
+import { addDays, format } from 'date-fns'
+import { isNil } from 'lodash'
+import { AllowedDatesOptions, DateConfig, Maybe } from '../../../types'
+
+export const getMinValueForDateInput = (
+  dateConfig: Maybe<DateConfig> | undefined
+): string | undefined => {
+  if (isNil(dateConfig)) {
+    return undefined
+  }
+
+  if (dateConfig.allowed_dates === AllowedDatesOptions.Future) {
+    if (dateConfig.include_date_of_response === true) {
+      return format(new Date(), 'yyyy-MM-dd')
+    }
+    const datePlusOneDay = addDays(new Date(), 1)
+
+    return format(datePlusOneDay, 'yyyy-MM-dd')
+  }
+  return undefined
+}

--- a/src/types/generated/types-orchestration.tsx
+++ b/src/types/generated/types-orchestration.tsx
@@ -176,6 +176,18 @@ export type ActivityTrack = {
   title: Scalars['String'];
 };
 
+export type AddIdentifierToPatientInput = {
+  identifier: IdentifierInput;
+  patient_id: Scalars['String'];
+};
+
+export type AddIdentifierToPatientPayload = Payload & {
+  __typename?: 'AddIdentifierToPatientPayload';
+  code: Scalars['String'];
+  patient?: Maybe<User>;
+  success: Scalars['Boolean'];
+};
+
 export type AddTrackInput = {
   pathway_id: Scalars['String'];
   track_id: Scalars['String'];
@@ -204,8 +216,15 @@ export type AddressInput = {
   zip?: InputMaybe<Scalars['String']>;
 };
 
+export enum AllowedDatesOptions {
+  All = 'ALL',
+  Future = 'FUTURE',
+  Past = 'PAST'
+}
+
 export type Answer = {
   __typename?: 'Answer';
+  label?: Maybe<Scalars['String']>;
   question_id: Scalars['String'];
   value: Scalars['String'];
   value_type: DataPointValueType;
@@ -316,6 +335,7 @@ export enum BooleanOperator {
 export type BrandingSettings = {
   __typename?: 'BrandingSettings';
   accent_color?: Maybe<Scalars['String']>;
+  custom_theme?: Maybe<Scalars['String']>;
   /** Auto progress to the next question when using the conversational display mode in Hosted Pages. */
   hosted_page_auto_progress?: Maybe<Scalars['Boolean']>;
   /** Automatically save question answers locally in Hosted Pages */
@@ -353,6 +373,13 @@ export type ChecklistPayload = Payload & {
   checklist?: Maybe<Checklist>;
   code: Scalars['String'];
   success: Scalars['Boolean'];
+};
+
+export type ChoiceRangeConfig = {
+  __typename?: 'ChoiceRangeConfig';
+  enabled?: Maybe<Scalars['Boolean']>;
+  max?: Maybe<Scalars['Float']>;
+  min?: Maybe<Scalars['Float']>;
 };
 
 export type ClinicalNotePayload = Payload & {
@@ -417,6 +444,7 @@ export type CreatePatientInput = {
   birth_date?: InputMaybe<Scalars['String']>;
   email?: InputMaybe<Scalars['String']>;
   first_name?: InputMaybe<Scalars['String']>;
+  identifier?: InputMaybe<Array<IdentifierInput>>;
   last_name?: InputMaybe<Scalars['String']>;
   /** Must be in valid E164 telephone number format */
   mobile_phone?: InputMaybe<Scalars['String']>;
@@ -435,6 +463,21 @@ export type CreatePatientPayload = Payload & {
   code: Scalars['String'];
   patient?: Maybe<User>;
   success: Scalars['Boolean'];
+};
+
+export type CurrentUser = {
+  __typename?: 'CurrentUser';
+  id: Scalars['ID'];
+  profile?: Maybe<UserProfile>;
+  tenant: Tenant;
+  tenant_id: Scalars['String'];
+};
+
+export type CurrentUserPayload = Payload & {
+  __typename?: 'CurrentUserPayload';
+  code: Scalars['String'];
+  success: Scalars['Boolean'];
+  user: CurrentUser;
 };
 
 export type DataPointDefinition = {
@@ -480,6 +523,7 @@ export enum DataPointSourceType {
   ExtensionWebhook = 'EXTENSION_WEBHOOK',
   Form = 'FORM',
   Pathway = 'PATHWAY',
+  PatientIdentifier = 'PATIENT_IDENTIFIER',
   PatientProfile = 'PATIENT_PROFILE',
   Step = 'STEP',
   Track = 'TRACK'
@@ -494,6 +538,12 @@ export enum DataPointValueType {
   StringsArray = 'STRINGS_ARRAY',
   Telephone = 'TELEPHONE'
 }
+
+export type DateConfig = {
+  __typename?: 'DateConfig';
+  allowed_dates?: Maybe<AllowedDatesOptions>;
+  include_date_of_response?: Maybe<Scalars['Boolean']>;
+};
 
 export type DateFilter = {
   gte?: InputMaybe<Scalars['String']>;
@@ -592,6 +642,12 @@ export type EvaluateFormRulesPayload = Payload & {
   success: Scalars['Boolean'];
 };
 
+export type ExclusiveOptionConfig = {
+  __typename?: 'ExclusiveOptionConfig';
+  enabled?: Maybe<Scalars['Boolean']>;
+  option_id?: Maybe<Scalars['String']>;
+};
+
 export type ExtensionActionField = {
   __typename?: 'ExtensionActionField';
   id: Scalars['ID'];
@@ -606,7 +662,9 @@ export enum ExtensionActionFieldType {
   Html = 'HTML',
   Json = 'JSON',
   Numeric = 'NUMERIC',
+  NumericArray = 'NUMERIC_ARRAY',
   String = 'STRING',
+  StringArray = 'STRING_ARRAY',
   Text = 'TEXT'
 }
 
@@ -820,6 +878,24 @@ export type IdFilter = {
   eq?: InputMaybe<Scalars['String']>;
 };
 
+export type Identifier = {
+  __typename?: 'Identifier';
+  system: Scalars['String'];
+  value: Scalars['String'];
+};
+
+export type IdentifierInput = {
+  system: Scalars['String'];
+  value: Scalars['String'];
+};
+
+export type IdentifierSystem = {
+  __typename?: 'IdentifierSystem';
+  display_name: Scalars['String'];
+  name: Scalars['String'];
+  system: Scalars['String'];
+};
+
 export type MarkMessageAsReadInput = {
   activity_id: Scalars['String'];
 };
@@ -866,8 +942,15 @@ export type MessagePayload = Payload & {
   success: Scalars['Boolean'];
 };
 
+export type MultipleSelectConfig = {
+  __typename?: 'MultipleSelectConfig';
+  exclusive_option?: Maybe<ExclusiveOptionConfig>;
+  range?: Maybe<ChoiceRangeConfig>;
+};
+
 export type Mutation = {
   __typename?: 'Mutation';
+  addIdentifierToPatient: AddIdentifierToPatientPayload;
   addTrack: AddTrackPayload;
   completeExtensionActivity: CompleteExtensionActivityPayload;
   createPatient: CreatePatientPayload;
@@ -886,13 +969,16 @@ export type Mutation = {
   retryApiCall: RetryApiCallPayload;
   retryPushToEmr: EmptyPayload;
   retryWebhookCall: RetryWebhookCallPayload;
+  /** @deprecated We will be deactivating this endpoint in the future. */
   saveBaselineInfo: EmptyPayload;
   scheduleTrack: ScheduleTrackPayload;
   startHostedActivitySession: StartHostedActivitySessionPayload;
   startHostedActivitySessionViaHostedPagesLink: StartHostedActivitySessionPayload;
+  /** Start a hosted pathway session for a patient uniquely identified by patient_id or patient_identifier. If neither patient_id or patient_identifier is provided, a new anonymous patient will be created. */
   startHostedPathwaySession: StartHostedPathwaySessionPayload;
   startHostedPathwaySessionFromLink: StartHostedPathwaySessionFromLinkPayload;
   startPathway: StartPathwayPayload;
+  startPathwayWithPatientIdentifier: StartPathwayWithPatientIdentifierPayload;
   stopPathway: EmptyPayload;
   stopTrack: StopTrackPayload;
   submitChecklist: SubmitChecklistPayload;
@@ -903,6 +989,11 @@ export type Mutation = {
   /** Update which patient was created after import request for logging purposes */
   updatePatientDemographicsQuery: UpdatePatientDemographicsQueryPayload;
   updatePatientLanguage: UpdatePatientLanguagePayload;
+};
+
+
+export type MutationAddIdentifierToPatientArgs = {
+  input: AddIdentifierToPatientInput;
 };
 
 
@@ -1027,6 +1118,11 @@ export type MutationStartPathwayArgs = {
 };
 
 
+export type MutationStartPathwayWithPatientIdentifierArgs = {
+  input: StartPathwayWithPatientIdentifierInput;
+};
+
+
 export type MutationStopPathwayArgs = {
   input: StopPathwayInput;
 };
@@ -1077,6 +1173,11 @@ export type MyCareOptions = {
 
 export type NumberArrayFilter = {
   in?: InputMaybe<Array<Scalars['Float']>>;
+};
+
+export type NumberConfig = {
+  __typename?: 'NumberConfig';
+  range?: Maybe<RangeConfig>;
 };
 
 export type Operand = {
@@ -1284,6 +1385,7 @@ export type PatientProfileInput = {
   birth_date?: InputMaybe<Scalars['String']>;
   email?: InputMaybe<Scalars['String']>;
   first_name?: InputMaybe<Scalars['String']>;
+  identifier?: InputMaybe<Array<IdentifierInput>>;
   last_name?: InputMaybe<Scalars['String']>;
   /** Must be in valid E164 telephone number format */
   mobile_phone?: InputMaybe<Scalars['String']>;
@@ -1407,6 +1509,7 @@ export type Query = {
   pathwayStepActivities: ActivitiesPayload;
   pathways: PathwaysPayload;
   patient: PatientPayload;
+  patientByIdentifier: PatientPayload;
   patientDemographicsQueryConfiguration: PatientDemographicsQueryConfigurationPayload;
   patientPathways: PatientPathwaysPayload;
   patients: PatientsPayload;
@@ -1423,7 +1526,7 @@ export type Query = {
   webhookCalls: WebhookCallsPayload;
   webhookCallsForPathwayDefinition: WebhookCallsPayload;
   webhookCallsForTenant: WebhookCallsPayload;
-  whoami: UserPayload;
+  whoami: CurrentUserPayload;
 };
 
 
@@ -1588,6 +1691,12 @@ export type QueryPatientArgs = {
 };
 
 
+export type QueryPatientByIdentifierArgs = {
+  system: Scalars['String'];
+  value: Scalars['String'];
+};
+
+
 export type QueryPatientPathwaysArgs = {
   filters?: InputMaybe<FilterPatientPathways>;
   patient_id: Scalars['String'];
@@ -1674,7 +1783,10 @@ export type Question = {
 
 export type QuestionConfig = {
   __typename?: 'QuestionConfig';
+  date?: Maybe<DateConfig>;
   mandatory: Scalars['Boolean'];
+  multiple_select?: Maybe<MultipleSelectConfig>;
+  number?: Maybe<NumberConfig>;
   phone?: Maybe<PhoneConfig>;
   recode_enabled?: Maybe<Scalars['Boolean']>;
   slider?: Maybe<SliderConfig>;
@@ -1701,6 +1813,13 @@ export enum QuestionType {
 
 export type Range = {
   __typename?: 'Range';
+  max?: Maybe<Scalars['Float']>;
+  min?: Maybe<Scalars['Float']>;
+};
+
+export type RangeConfig = {
+  __typename?: 'RangeConfig';
+  enabled?: Maybe<Scalars['Boolean']>;
   max?: Maybe<Scalars['Float']>;
   min?: Maybe<Scalars['Float']>;
 };
@@ -1908,6 +2027,7 @@ export type StartHostedActivitySessionViaHostedPagesLinkInput = {
 
 export type StartHostedPathwaySessionFromLinkInput = {
   id: Scalars['String'];
+  patient_identifier?: InputMaybe<IdentifierInput>;
 };
 
 export type StartHostedPathwaySessionFromLinkPayload = Payload & {
@@ -1923,7 +2043,10 @@ export type StartHostedPathwaySessionInput = {
   /** ISO 639-1 shortcode */
   language?: InputMaybe<Scalars['String']>;
   pathway_definition_id: Scalars['String'];
+  /** Unique id of the patient in Awell, if not provided, patient identifier will be tried to uniquely identify the patient. */
   patient_id?: InputMaybe<Scalars['String']>;
+  /** If no patient_id is provided this field will be used to uniquely identify the patient. */
+  patient_identifier?: InputMaybe<IdentifierInput>;
   success_url?: InputMaybe<Scalars['String']>;
 };
 
@@ -1941,12 +2064,29 @@ export type StartPathwayInput = {
   data_points?: InputMaybe<Array<DataPointInput>>;
   pathway_definition_id: Scalars['String'];
   patient_id: Scalars['String'];
+  release_id?: InputMaybe<Scalars['String']>;
 };
 
 export type StartPathwayPayload = Payload & {
   __typename?: 'StartPathwayPayload';
   code: Scalars['String'];
   pathway_id: Scalars['String'];
+  stakeholders: Array<Stakeholder>;
+  success: Scalars['Boolean'];
+};
+
+export type StartPathwayWithPatientIdentifierInput = {
+  data_points?: InputMaybe<Array<DataPointInput>>;
+  pathway_definition_id: Scalars['String'];
+  patient_identifier: IdentifierInput;
+  release_id?: InputMaybe<Scalars['String']>;
+};
+
+export type StartPathwayWithPatientIdentifierPayload = Payload & {
+  __typename?: 'StartPathwayWithPatientIdentifierPayload';
+  code: Scalars['String'];
+  pathway_id: Scalars['String'];
+  patient_id: Scalars['String'];
   stakeholders: Array<Stakeholder>;
   success: Scalars['Boolean'];
 };
@@ -2172,6 +2312,7 @@ export type Tenant = {
   __typename?: 'Tenant';
   accent_color: Scalars['String'];
   hosted_page_title: Scalars['String'];
+  identifier_systems?: Maybe<Array<IdentifierSystem>>;
   is_default: Scalars['Boolean'];
   logo_path: Scalars['String'];
   name: Scalars['String'];
@@ -2261,15 +2402,7 @@ export type User = {
   __typename?: 'User';
   id: Scalars['ID'];
   profile?: Maybe<UserProfile>;
-  tenant: Tenant;
   tenant_id: Scalars['String'];
-};
-
-export type UserPayload = Payload & {
-  __typename?: 'UserPayload';
-  code: Scalars['String'];
-  success: Scalars['Boolean'];
-  user: User;
 };
 
 export type UserProfile = {
@@ -2278,6 +2411,7 @@ export type UserProfile = {
   birth_date?: Maybe<Scalars['String']>;
   email?: Maybe<Scalars['String']>;
   first_name?: Maybe<Scalars['String']>;
+  identifier?: Maybe<Array<Identifier>>;
   last_name?: Maybe<Scalars['String']>;
   mobile_phone?: Maybe<Scalars['String']>;
   name?: Maybe<Scalars['String']>;


### PR DESCRIPTION
- Add new validation rule for date responses
  - User sees an error when date response value violates one of the rules defined in the question configuration.
- Add min/max date restriction in calendar input.
  - All invalid dates are blurred in the calendar UI. 