### PR TITLE
[tp-1640-fix-rangeinput-slider] Set values based component render

### DIFF
--- a/src/atoms/rangeInput/RangeInput.tsx
+++ b/src/atoms/rangeInput/RangeInput.tsx
@@ -192,12 +192,11 @@ export const RangeInput = ({
             onChange={handleValueChange}
             onFocus={(e) => {
               if (!touched) {
-                setInternalValue(max.toString())
-                onChange(e)
+                handleValueChange(e)
+              } else {
+                setTouched(true)
+                onTouched(true)
               }
-
-              setTouched(true)
-              onTouched(true)
             }}
             aria-valuemin={min}
             aria-valuemax={max}

--- a/src/atoms/rangeInput/RangeInput.tsx
+++ b/src/atoms/rangeInput/RangeInput.tsx
@@ -194,6 +194,7 @@ export const RangeInput = ({
               setTouched(true)
               onTouched(true)
             }}
+            value={internalValue}
             aria-valuemin={min}
             aria-valuemax={max}
             aria-valuenow={(props.value || min) as number}

--- a/src/atoms/rangeInput/RangeInput.tsx
+++ b/src/atoms/rangeInput/RangeInput.tsx
@@ -190,11 +190,15 @@ export const RangeInput = ({
               touched ? classes.showThumb : classes.hideThumb
             }`}
             onChange={handleValueChange}
-            onFocus={() => {
+            onFocus={(e) => {
+              if (!touched) {
+                setInternalValue(max.toString())
+                onChange(e)
+              }
+
               setTouched(true)
               onTouched(true)
             }}
-            value={internalValue}
             aria-valuemin={min}
             aria-valuemax={max}
             aria-valuenow={(props.value || min) as number}


### PR DESCRIPTION
This sets value on the input render. Prev logic was a bit weird when input stayed uncontrolled and logic was based not on the value but touch event. 

@nckhell Is there a way to Q&A it? This Component logic os not intuitive at all with many states and some unnecessary stuff IMHO.