### PR TITLE
chore(cal-com): support custom domains

### DIFF
--- a/src/atoms/scheduling/cal.com/CalDotComScheduling.stories.tsx
+++ b/src/atoms/scheduling/cal.com/CalDotComScheduling.stories.tsx
@@ -5,7 +5,6 @@ import {
   CalDotComScheduling as CalDotComSchedulingComponent,
   CalDotComSchedulingProps,
 } from '.'
-import { action } from '@storybook/addon-actions'
 
 export default {
   title: 'Atoms/Scheduling/Cal.com',
@@ -14,6 +13,11 @@ export default {
     calLink: {
       control: 'text',
       defaultValue: 'nick-hellemans-k1brip/15min',
+    },
+    calOrigin: {
+      control: 'text',
+      name: 'origin',
+      defaultValue: 'https://cal.com',
     },
     onBookingSuccessful: { action: 'bookingSuccessful' },
     hideEventTypeDetails: {
@@ -46,6 +50,7 @@ export default {
 
 export const CalDotComScheduling: Story<CalDotComSchedulingProps> = ({
   calLink,
+  calOrigin,
   onBookingSuccessful,
   hideEventTypeDetails,
   metadata,
@@ -53,6 +58,7 @@ export const CalDotComScheduling: Story<CalDotComSchedulingProps> = ({
   return (
     <CalDotComSchedulingComponent
       calLink={calLink}
+      calOrigin={calOrigin}
       onBookingSuccessful={onBookingSuccessful}
       hideEventTypeDetails={hideEventTypeDetails}
       metadata={metadata}

--- a/src/atoms/scheduling/cal.com/CalDotComScheduling.tsx
+++ b/src/atoms/scheduling/cal.com/CalDotComScheduling.tsx
@@ -1,10 +1,11 @@
-import { FC, useEffect } from 'react'
+import React, { FC, useEffect } from 'react'
 import Cal, { getCalApi } from '@calcom/embed-react'
 import { useAccentColor } from '../../../hooks/useAccentColor'
 import { type BookingSuccessfulFunction } from './calDotComTypes'
 
 export interface CalDotComSchedulingProps {
   calLink: string
+  calOrigin?: string
   onBookingSuccessful: BookingSuccessfulFunction
   hideEventTypeDetails?: boolean
   /**
@@ -17,6 +18,7 @@ export interface CalDotComSchedulingProps {
 
 export const CalDotComScheduling: FC<CalDotComSchedulingProps> = ({
   calLink,
+  calOrigin,
   hideEventTypeDetails = false,
   onBookingSuccessful,
   metadata,
@@ -81,6 +83,7 @@ export const CalDotComScheduling: FC<CalDotComSchedulingProps> = ({
   return (
     <Cal
       calLink={composedCalLink}
+      calOrigin={calOrigin ?? 'https://cal.com'}
       style={{ width: '100%', height: '100%', overflow: 'hidden' }}
     />
   )

--- a/src/hostedPages/activities/scheduling/cal.com/calDotcomActivity.stories.tsx
+++ b/src/hostedPages/activities/scheduling/cal.com/calDotcomActivity.stories.tsx
@@ -13,6 +13,11 @@ export default {
       control: 'text',
       defaultValue: 'nick-hellemans-k1brip/15min',
     },
+    calOrigin: {
+      control: 'text',
+      name: 'origin',
+      defaultValue: 'https://cal.com',
+    },
     hideEventTypeDetails: {
       control: 'boolean',
       defaultValue: false,
@@ -29,6 +34,7 @@ export default {
 
 export const CalDotComActivity: Story<CalDotComActivityProps> = ({
   calLink,
+  calOrigin,
   hideEventTypeDetails,
 }) => {
   return (
@@ -40,6 +46,7 @@ export const CalDotComActivity: Story<CalDotComActivityProps> = ({
     >
       <CalDotcomActivityComponent
         calLink={calLink}
+        calOrigin={calOrigin ?? 'https://cal.com'}
         onBookingSuccessful={() => alert('hey')}
         hideEventTypeDetails={hideEventTypeDetails}
       />

--- a/src/hostedPages/activities/scheduling/cal.com/types.ts
+++ b/src/hostedPages/activities/scheduling/cal.com/types.ts
@@ -2,6 +2,7 @@ import { CalDotComBookingSuccessfulFunction } from '../../../../atoms/scheduling
 
 export interface CalDotComActivityProps {
   calLink: string
+  calOrigin?: string
   onBookingSuccessful: CalDotComBookingSuccessfulFunction
   hideEventTypeDetails: boolean
 }


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Added support for custom domains by introducing a `calOrigin` property in both `CalDotComScheduling` and `CalDotcomActivity` components.
- Updated Storybook stories to include the `calOrigin` property with a default value of 'https://cal.com'.
- Modified components to use the `calOrigin` property, allowing for enterprise customization.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CalDotComScheduling.stories.tsx</strong><dd><code>Add `calOrigin` property to CalDotComScheduling story</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/atoms/scheduling/cal.com/CalDotComScheduling.stories.tsx

<li>Added <code>calOrigin</code> property to story arguments.<br> <li> Set default value for <code>calOrigin</code> to 'https://cal.com'.<br> <li> Passed <code>calOrigin</code> to <code>CalDotComSchedulingComponent</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/ui-library/pull/158/files#diff-0cbdc8faf60f680616c89ab21214df1f17ece5d74880177d1089458f83abdf4e">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>CalDotComScheduling.tsx</strong><dd><code>Support custom `calOrigin` in CalDotComScheduling component</code></dd></summary>
<hr>

src/atoms/scheduling/cal.com/CalDotComScheduling.tsx

<li>Introduced optional <code>calOrigin</code> property in <code>CalDotComSchedulingProps</code>.<br> <li> Used <code>calOrigin</code> in <code>Cal</code> component with a default fallback.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/ui-library/pull/158/files#diff-3a38f3730d1a09f845d74a249b7ccf317f71112cfda6258f86abc1bbf10db487">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>calDotcomActivity.stories.tsx</strong><dd><code>Add `calOrigin` property to CalDotcomActivity story</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/hostedPages/activities/scheduling/cal.com/calDotcomActivity.stories.tsx

<li>Added <code>calOrigin</code> property to story arguments.<br> <li> Set default value for <code>calOrigin</code> to 'https://cal.com'.<br> <li> Passed <code>calOrigin</code> to <code>CalDotcomActivityComponent</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/ui-library/pull/158/files#diff-2e2567bea09678f0a52921b1f72291ec7b876c95abcfda33eb07435d4b00b5f8">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>types.ts</strong><dd><code>Extend CalDotComActivityProps with `calOrigin`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/hostedPages/activities/scheduling/cal.com/types.ts

- Added optional `calOrigin` property to `CalDotComActivityProps`.



</details>


  </td>
  <td><a href="https://github.com/awell-health/ui-library/pull/158/files#diff-d7fe95ea8f3f8906d06e937ddcac9289489589ad3c3ae0c17e19a2ac2879d2a5">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information