### PR TITLE
fix(trademark): bump padding in trademark

### DIFF
--- a/src/hostedPages/activities/form/form.module.scss
+++ b/src/hostedPages/activities/form/form.module.scss
@@ -81,6 +81,7 @@
   color: var(--awell-slate500);
   font-style: italic;
   text-align: center;
+  padding-bottom: var(--awell-spacing-4);
 
   @media (min-width: 640px) {
     font-size: var(--font-size-sm);


### PR DESCRIPTION
### **User description**
the padding from the trademark is necessary; unfortunately, storybook and actual deployment in hosted pages is inconsistent


___

### **PR Type**
enhancement


___

### **Description**
- Increased the bottom padding of the `.trademark` class in the SCSS file to ensure consistent styling across different environments, such as Storybook and actual deployments.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>form.module.scss</strong><dd><code>Increase bottom padding for trademark class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/hostedPages/activities/form/form.module.scss

<li>Increased bottom padding for the <code>.trademark</code> class.<br> <li> Ensures consistent styling across different environments.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/ui-library/pull/166/files#diff-f2665e7291ae0c4626d6a3c15321a47aba912a813d8b35726c888612205e0cb7">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information