### PR TITLE
ET-495: preserve line breaks in escaped strings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@awell-health/ui-library",
-  "version": "0.1.66",
+  "version": "0.1.84",
   "description": "UI components to integrate with Awell Health",
   "repository": {
     "type": "git",

--- a/src/atoms/richTextViewer/RichTextViewer.tsx
+++ b/src/atoms/richTextViewer/RichTextViewer.tsx
@@ -8,10 +8,23 @@ interface RichTextViewerProps {
 export const RichTextViewer = ({
   content,
 }: RichTextViewerProps): JSX.Element => {
+  /**
+   * Ensure that escaped new line characters (\n)
+   * are properly rendered as line breaks (<br />) in HTML.
+   *
+   * Example:
+   * Input: "Line 1\nLine 2"
+   * Output: "Line 1<br />Line 2"
+   *
+   * This is particularly useful when dealing with escaped strings
+   * where new lines are indicated as \n and need to be displayed correctly in HTML.
+   */
+  const contentWithLineBreaks = content.split('\n').join('<br />')
+
   return (
     <div
       className={classes.content}
-      dangerouslySetInnerHTML={{ __html: content }}
+      dangerouslySetInnerHTML={{ __html: contentWithLineBreaks }}
     />
   )
 }


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Enhanced the `RichTextViewer` component to convert escaped newline characters (`\n`) into HTML line breaks (`<br />`).
- This change ensures that multiline strings are displayed correctly in HTML.
- Added a detailed comment explaining the transformation process and its purpose.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RichTextViewer.tsx</strong><dd><code>Convert escaped newlines to HTML line breaks in RichTextViewer</code></dd></summary>
<hr>

src/atoms/richTextViewer/RichTextViewer.tsx

<li>Added logic to convert escaped newline characters to HTML line breaks.<br> <li> Updated the <code>dangerouslySetInnerHTML</code> to use the modified content.<br> <li> Included a comment explaining the purpose of the change.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/ui-library/pull/175/files#diff-e3d26bf4df88109ab879b6f62b66a9aa71a191e3cf148c01155549d38b3ca92d">+14/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information