### PR TITLE
Update on change hook after phone is formatted by library

### DIFF
--- a/src/atoms/phoneInputField/PhoneInputField.tsx
+++ b/src/atoms/phoneInputField/PhoneInputField.tsx
@@ -93,6 +93,18 @@ export const PhoneInputField = ({
     setCountry(iso2)
   }
 
+  const onPaste = (e: React.ClipboardEvent<HTMLInputElement>) => {
+    const phoneNumber = e.clipboardData.getData('text') ?? ''
+
+    // if number contains + (country code), remove it from input, before pasting new value
+    if (phoneNumber.includes('+')) {
+      if (inputRef.current) {
+        inputRef.current.value = ''
+        inputRef.current.dispatchEvent(new Event('change'))
+      }
+    }
+  }
+
   return (
     <div className={classes.awell_input_field_wrapper}>
       <QuestionLabel htmlFor={id} label={label} mandatory={mandatory} />
@@ -121,6 +133,7 @@ export const PhoneInputField = ({
           value={phone}
           data-testid={`input-${id}`}
           dir="ltr"
+          onPaste={onPaste}
         />
       </div>
     </div>

--- a/src/atoms/phoneInputField/PhoneInputField.tsx
+++ b/src/atoms/phoneInputField/PhoneInputField.tsx
@@ -1,4 +1,4 @@
-import React, { InputHTMLAttributes, MouseEventHandler } from 'react'
+import React, { InputHTMLAttributes, MouseEventHandler, useEffect } from 'react'
 import classes from './phoneInputField.module.scss'
 import { QuestionLabel } from '../questionLabel'
 import 'react-international-phone/style.css'
@@ -81,9 +81,12 @@ export const PhoneInputField = ({
       forceDialCode,
     })
 
+  useEffect(() => {
+    onChange({ target: { value: phone } })
+  }, [phone, onChange])
+
   const handleInputChange: React.ChangeEventHandler<HTMLInputElement> = (e) => {
     handlePhoneValueChange(e)
-    onChange(e)
   }
 
   const handleCountrySelect: (country: ParsedCountry) => void = ({ iso2 }) => {


### PR DESCRIPTION
### **User description**
Allows to paste input phone value in a various formats, that are parsed by helper library, before triggering `onChange` prop.


___

### **PR Type**
enhancement


___

### **Description**
- Introduced a `useEffect` hook to ensure the `onChange` prop is triggered whenever the `phone` value is updated, improving the handling of formatted phone numbers.
- Removed the redundant `onChange` call from the `handleInputChange` function, streamlining the code.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PhoneInputField.tsx</strong><dd><code>Enhance phone input handling with <code>useEffect</code> for formatted value <br>updates</code></dd></summary>
<hr>

src/atoms/phoneInputField/PhoneInputField.tsx

<li>Added a <code>useEffect</code> hook to trigger the <code>onChange</code> prop when the <code>phone</code> <br>value changes.<br> <li> Removed redundant <code>onChange</code> call from the <code>handleInputChange</code> function.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/ui-library/pull/177/files#diff-26f4f0edd04195472e04b5f6a76c4c0448047fdf4e885f4e47a57eb83d03806b">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information