### PR TITLE
ET-848: Add local storage persistence for select and ICD options

### DIFF
--- a/src/atoms/select/Select.tsx
+++ b/src/atoms/select/Select.tsx
@@ -11,7 +11,7 @@ import React, {
 import classes from './select.module.scss'
 import { QuestionLabel } from '../questionLabel'
 import { type Option } from './types'
-import { isNil, noop } from 'lodash'
+import { isEmpty, isNil, noop } from 'lodash'
 import { FixedSizeList as List } from 'react-window'
 
 export interface SelectProps
@@ -147,9 +147,10 @@ export const Select = ({
       return value as Array<Option>
     }
     if (type === 'single') {
-      return [
+      const matchingOption = [
         options.find((option) => value === option.value) ?? undefined,
       ].filter((option) => option !== undefined) as Array<Option>
+      return matchingOption
     }
     return []
   }
@@ -213,6 +214,16 @@ export const Select = ({
       setFilteredOptions(options)
     }
   }, [options])
+
+  useEffect(() => {
+    /*
+     * When the form is refreshed, we want to set the searchValue to the label of the first selected option
+     * This is to ensure that the searchValue is set to the label of the first selected option
+     */
+    if (allowSearchAfterSelect && selected.length > 0 && isEmpty(searchValue)) {
+      setSearchValue(selected[0]?.label ?? '')
+    }
+  }, [selected, allowSearchAfterSelect, searchValue])
 
   useEffect(() => {
     if (isOpen) {
@@ -301,6 +312,9 @@ export const Select = ({
   const getDisplayValue = (): string => {
     if (filtering) {
       if (allowSearchAfterSelect) {
+        if (isEmpty(searchValue) && selected.length > 0) {
+          return selected[0]?.label ?? ''
+        }
         return searchValue ?? ''
       } else if (selected.length === 0) {
         return searchValue ?? ''

--- a/src/atoms/select/Select.tsx
+++ b/src/atoms/select/Select.tsx
@@ -206,6 +206,15 @@ export const Select = ({
   }, [isOpen, handleClickOutside])
 
   useEffect(() => {
+    if (
+      !isNil(onSearch) &&
+      allowSearchAfterSelect &&
+      searchValue === selected[0]?.label
+    ) {
+      // no need to open the dropdown in this case as search exactly matches the label of the first selected option
+      setIsOpen(false)
+      return
+    }
     if (!isNil(onSearch) && options.length > 0) {
       setIsOpen(true)
       setFilteredOptions(options)

--- a/src/hooks/useIcdClassificationList/useIcdClassficationList.ts
+++ b/src/hooks/useIcdClassificationList/useIcdClassficationList.ts
@@ -5,9 +5,9 @@ import { debounce } from 'lodash'
 
 const ICD_10_CLASSIFICATION_ENDPOINT = `https://clinicaltables.nlm.nih.gov/api/icd10cm/v3/search`
 
-export const useICDClassificationList = () => {
+export const useICDClassificationList = (questionId: string) => {
   const [options, setOptions] = useState<Array<Option>>(() => {
-    const savedOptions = localStorage.getItem('icdOptions')
+    const savedOptions = localStorage.getItem(`icdOptions-${questionId}`)
     return savedOptions ? JSON.parse(savedOptions) : []
   })
   const [loading, setLoading] = useState<boolean>(false)
@@ -38,7 +38,10 @@ export const useICDClassificationList = () => {
       )
 
       setOptions(icdOptions)
-      localStorage.setItem('icdOptions', JSON.stringify(icdOptions))
+      localStorage.setItem(
+        `icdOptions-${questionId}`,
+        JSON.stringify(icdOptions)
+      )
     } catch (err) {
       setError('Failed to fetch ICD-10 codes')
     } finally {
@@ -66,7 +69,7 @@ export const useICDClassificationList = () => {
 
   const onIcdClassificationSearchChange = (val: string) => {
     setSearchValue(val)
-    localStorage.setItem('icdSearchValue', val)
+    localStorage.setItem(`icdSearchValue-${questionId}`, val)
   }
 
   return { options, loading, error, onIcdClassificationSearchChange }

--- a/src/hooks/useIcdClassificationList/useIcdClassficationList.ts
+++ b/src/hooks/useIcdClassificationList/useIcdClassficationList.ts
@@ -6,7 +6,10 @@ import { debounce } from 'lodash'
 const ICD_10_CLASSIFICATION_ENDPOINT = `https://clinicaltables.nlm.nih.gov/api/icd10cm/v3/search`
 
 export const useICDClassificationList = () => {
-  const [options, setOptions] = useState<Array<Option>>([])
+  const [options, setOptions] = useState<Array<Option>>(() => {
+    const savedOptions = localStorage.getItem('icdOptions')
+    return savedOptions ? JSON.parse(savedOptions) : []
+  })
   const [loading, setLoading] = useState<boolean>(false)
   const [error, setError] = useState<string | null>(null)
   const [searchValue, setSearchValue] = useState('')
@@ -35,6 +38,7 @@ export const useICDClassificationList = () => {
       )
 
       setOptions(icdOptions)
+      localStorage.setItem('icdOptions', JSON.stringify(icdOptions))
     } catch (err) {
       setError('Failed to fetch ICD-10 codes')
     } finally {
@@ -62,6 +66,7 @@ export const useICDClassificationList = () => {
 
   const onIcdClassificationSearchChange = (val: string) => {
     setSearchValue(val)
+    localStorage.setItem('icdSearchValue', val)
   }
 
   return { options, loading, error, onIcdClassificationSearchChange }

--- a/src/molecules/question/Question.tsx
+++ b/src/molecules/question/Question.tsx
@@ -41,7 +41,7 @@ export const QuestionData = ({
     options: icdClassificationOptions,
     loading: optionsLoading,
     onIcdClassificationSearchChange,
-  } = useICDClassificationList()
+  } = useICDClassificationList(question.id)
 
   switch (question.userQuestionType) {
     case UserQuestionType.YesNo:


### PR DESCRIPTION
### **User description**
…elect and ICD options

The ICD form value is now saved in local storage. So when user opens the same questionnaire, it is persisted:

![2025-01-29 18 57 38](https://github.com/user-attachments/assets/61bdc242-ee39-4dce-bbcf-a037927a1e49)

- Enhance Select component to handle search value when options are selected
- Implement local storage caching for ICD classification options and search value
- Improve user experience by preserving search context across page reloads


___

### **PR Type**
Enhancement


___

### **Description**
- Added local storage persistence for ICD classification options and search value.

- Enhanced `Select` component to handle search value post-selection.

- Improved user experience by preserving search context across reloads.

- Introduced logic to initialize search value from selected options.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Select.tsx</strong><dd><code>Enhance Select component with search value handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/atoms/select/Select.tsx

<li>Added logic to initialize search value from selected options.<br> <li> Enhanced handling of search value for filtering and selection.<br> <li> Improved <code>getDisplayValue</code> logic to handle empty search values.<br> <li> Refactored code for better readability and functionality.


</details>


  </td>
  <td><a href="https://github.com/awell-health/ui-library/pull/183/files#diff-79fef6f28eb0d49aa88173c623766e2af6e6281aa28a5a0cbb7080079c2b9fc3">+16/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>useIcdClassficationList.ts</strong><dd><code>Add local storage persistence for ICD classification</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/hooks/useIcdClassificationList/useIcdClassficationList.ts

<li>Added local storage caching for ICD options and search value.<br> <li> Initialized options state from local storage if available.<br> <li> Persisted search value changes to local storage.<br> <li> Improved error handling for ICD code fetching.


</details>


  </td>
  <td><a href="https://github.com/awell-health/ui-library/pull/183/files#diff-a44792e29d8a48539b940ca4183ba2bd5e9c42ae4c64d4580b0a57c697b3f060">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>