### PR TITLE
update node version to 18 in publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -11,7 +11,7 @@ jobs:
       # Setup .npmrc file to publish to npm
       - uses: actions/setup-node@v3
         with:
-          node-version: '16.x'
+          node-version: '18.x'
           registry-url: 'https://registry.npmjs.org'
       - name: '📦 Installing dependencies'
         run: yarn --frozen-lockfile


### PR DESCRIPTION
### **User description**
Reason: https://github.com/awell-health/ui-library/actions/runs/13794852670/job/38583853867

The design system uses `react-day-picker` which requires v18 of node. I don't see a drawback here. But would like to mitigate the risk of introducing a breaking change.


___

### **PR Type**
- Enhancement



___

### **Description**
- Upgrade node version from 16.x to 18.x.

- Update npm publish workflow configuration.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>npm-publish.yaml</strong><dd><code>Update node version in workflow configuration.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/npm-publish.yaml

<li>Changed <code>node-version</code> from '16.x' to '18.x'.<br> <li> Retained npm registry settings.


</details>


  </td>
  <td><a href="https://github.com/awell-health/ui-library/pull/187/files#diff-af366642b9e094cd419ba16394d0b0a265693ec1a4eaa049505a03ee9d231d00">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>