### PR TITLE
feat(form): add input validation to short text question

### DIFF
--- a/src/molecules/question/Question.tsx
+++ b/src/molecules/question/Question.tsx
@@ -264,7 +264,13 @@ export const QuestionData = ({
           name={question.id}
           control={control}
           defaultValue=""
-          rules={{ required: config?.mandatory }}
+          rules={{
+            required: config?.mandatory,
+            ...(config?.input_validation?.pattern && {
+              value: new RegExp(config?.input_validation?.pattern),
+              message: config?.input_validation?.helper_text,
+            }),
+          }}
           render={({ field: { onChange, value } }) => (
             <InputField
               // eslint-disable-next-line jsx-a11y/no-autofocus

--- a/src/types/generated/types-orchestration.tsx
+++ b/src/types/generated/types-orchestration.tsx
@@ -689,6 +689,7 @@ export enum ElementStatus {
 
 export enum ElementType {
   Action = 'ACTION',
+  Agent = 'AGENT',
   Pathway = 'PATHWAY',
   Step = 'STEP',
   Track = 'TRACK',
@@ -1040,6 +1041,28 @@ export type IdentityVerificationPayload = Payload & {
   success: Scalars['Boolean'];
 };
 
+export type InputValidationAllowed = {
+  __typename?: 'InputValidationAllowed';
+  letters?: Maybe<Scalars['Boolean']>;
+  numbers?: Maybe<Scalars['Boolean']>;
+  special?: Maybe<Scalars['Boolean']>;
+  whitespace?: Maybe<Scalars['Boolean']>;
+};
+
+export type InputValidationConfig = {
+  __typename?: 'InputValidationConfig';
+  helper_text?: Maybe<Scalars['String']>;
+  mode?: Maybe<Scalars['String']>;
+  pattern?: Maybe<Scalars['String']>;
+  simpleConfig?: Maybe<InputValidationSimpleConfig>;
+};
+
+export type InputValidationSimpleConfig = {
+  __typename?: 'InputValidationSimpleConfig';
+  allowed?: Maybe<InputValidationAllowed>;
+  exactLength?: Maybe<Scalars['Float']>;
+};
+
 export type MarkMessageAsReadInput = {
   activity_id: Scalars['String'];
 };
@@ -1055,7 +1078,7 @@ export type Message = {
   __typename?: 'Message';
   attachments?: Maybe<Array<MessageAttachment>>;
   body: Scalars['String'];
-  format: MessageFormat;
+  format?: Maybe<MessageFormat>;
   id: Scalars['ID'];
   subject?: Maybe<Scalars['String']>;
 };
@@ -1428,6 +1451,8 @@ export type Pathway = {
 export type PathwayContext = {
   __typename?: 'PathwayContext';
   action_id?: Maybe<Scalars['String']>;
+  agent_id?: Maybe<Scalars['String']>;
+  agent_thread_id?: Maybe<Scalars['String']>;
   instance_id: Scalars['String'];
   pathway_id: Scalars['String'];
   step_id?: Maybe<Scalars['String']>;
@@ -2022,6 +2047,7 @@ export type QuestionConfig = {
   __typename?: 'QuestionConfig';
   date?: Maybe<DateConfig>;
   file_storage?: Maybe<FileStorageQuestionConfig>;
+  input_validation?: Maybe<InputValidationConfig>;
   mandatory: Scalars['Boolean'];
   multiple_select?: Maybe<MultipleSelectConfig>;
   number?: Maybe<NumberConfig>;


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add pattern-based validation to short text.

- Extend GraphQL schema with InputValidation types.

- Introduce `Agent` element type and optional IDs.

- Make Message.format optional in schema.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Question.tsx</strong><dd><code>Pattern validation in ShortText question component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/molecules/question/Question.tsx

<li>Added pattern-based validation for short text input.<br> <li> Integrated helper_text for validation feedback.


</details>


  </td>
  <td><a href="https://github.com/awell-health/ui-library/pull/196/files#diff-05ffd6b6d024113ea1d54c7d9f22ba430d65ef7d1caa9f03b4ed2fc299afa828">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>types-orchestration.tsx</strong><dd><code>Extend GraphQL schema for input validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/types/generated/types-orchestration.tsx

<li>Introduced InputValidation types (Allowed, Config, SimpleConfig).<br> <li> Added <code>input_validation</code> field to QuestionConfig.<br> <li> Added <code>Agent</code> enum entry and pathway agent IDs.<br> <li> Marked Message.format as optional.


</details>


  </td>
  <td><a href="https://github.com/awell-health/ui-library/pull/196/files#diff-4995b7e929870b0fe0dbce1750ade89d9c3276c442538495b3bceeb34d8b00d3">+27/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>