### PR TITLE
Rev 294 agent generated forms are stuck in an infinite loading state

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@awell-health/ui-library",
-  "version": "0.1.116",
+  "version": "0.1.117",
   "description": "UI components to integrate with Awell Health",
   "repository": {
     "type": "git",

--- a/src/hooks/useForm/helpers.ts
+++ b/src/hooks/useForm/helpers.ts
@@ -19,6 +19,7 @@ import {
   InputValidationErrorType,
   NumberValidationErrorType,
 } from '../useValidate/useValidate'
+import { isNil } from 'lodash'
 
 export const getDefaultValue = (question: Question): AnswerValue => {
   switch (question.userQuestionType) {
@@ -116,7 +117,7 @@ export const updateVisibilityForTraditionalForm = (
     return questions.map((question) => ({
       ...question,
       visible:
-        question.rule === null ||
+        isNil(question.rule) ||
         (Array.isArray(question.rule?.conditions) &&
           question.rule?.conditions.length === 0),
     }))


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Replace `question.rule === null` with `isNil` for rule checks.

- Fix infinite loading in generated forms.

- Bump package version to 0.1.117.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>helpers.ts</strong><dd><code>Use isNil for rule null/undefined check</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/hooks/useForm/helpers.ts

<li>Added import of <code>isNil</code> from lodash.<br> <li> Replaced null check with <code>isNil</code> for rule visibility.


</details>


  </td>
  <td><a href="https://github.com/awell-health/ui-library/pull/207/files#diff-ab956e1ce9bda8a8d0eaa345abfa3de7ab929be3844f642a06e92ef25900d1de">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Bump version to 0.1.117</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

package.json

- Bumped version to 0.1.117.


</details>


  </td>
  <td><a href="https://github.com/awell-health/ui-library/pull/207/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>